### PR TITLE
Update SP1 to work

### DIFF
--- a/examples/sp1/routes/sso.js
+++ b/examples/sp1/routes/sso.js
@@ -88,7 +88,7 @@ router.get('/spinitsso-redirect',function(req,res){
     });
 });
 
-router.post('/acs/:idp',function(req,res,next){
+router.post('/acs/:idp?',function(req,res,next){
     var _idp, _sp;
     if(req.params.idp === 'onelogin'){
         _idp = oneLoginIdP;


### PR DESCRIPTION
Currently the SP1 example/workflow doesn't work as described in the readme, this is due to the changes made for the 'onelogin'. Added this little questionmark will make sure both work, the paramater is available when used, but otherwise not skipping the route whenever it doesn't.