### PR TITLE
Fix X509 Certificate reading error

### DIFF
--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -57,7 +57,7 @@ var utility = function() {
         * @return {string} certificiate in string format
         */
         parseCerFile: function parseCerFile(certFile){
-            return fs.readFileSync(certFile).toString().replace(/\n/g, '').replace(/\r/g, '').replace('-----BEGIN CERTIFICATE-----', '').replace('-----END CERTIFICATE-----');
+            return fs.readFileSync(certFile).toString().replace(/\n/g, '').replace(/\r/g, '').replace('-----BEGIN CERTIFICATE-----', '').replace('-----END CERTIFICATE-----', '');
         },
         /**
         * @desc Normalize the string in .pem format without line break, header and footer
@@ -65,7 +65,7 @@ var utility = function() {
         * @return {string} private key in string format
         */
         normalizePemString: function normalizePemString(pemString){
-            return pemString.toString().replace(/\n/g, '').replace(/\r/g, '').replace('-----BEGIN RSA PRIVATE KEY-----', '').replace('-----END RSA PRIVATE KEY-----');
+            return pemString.toString().replace(/\n/g, '').replace(/\r/g, '').replace('-----BEGIN RSA PRIVATE KEY-----', '').replace('-----END RSA PRIVATE KEY-----', '');
         },
         /**
         * @desc Return the complete URL


### PR DESCRIPTION
When the X509 certificate was read an extra `undefined` was appended to the data.

The last `.replace()` was missing the substitution string parameter, which was defaulted to `undefined`.