### PR TITLE
Fixed sp-metadata assertion tag indexing

### DIFF
--- a/lib/SPMetadata.js
+++ b/lib/SPMetadata.js
@@ -72,9 +72,10 @@ module.exports = function(meta) {
         }
 
         if(assertionConsumerService && assertionConsumerService.length > 0) {
+            var _indexCount = 0;
             assertionConsumerService.forEach(function(a) {
                 var _attr = {};
-                var _indexCount = 0;
+                
                 if(a.isDefault) {
                     _attr.isDefault = true;
                 }


### PR DESCRIPTION
Before this changes index value was 0 in any AssertionConsumerService tags

```xml
<AssertionConsumerService index="0" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
Location="/sso/acs"/>
<AssertionConsumerService index="0" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
Location="/sso/acs"/>
```