### PR TITLE
fix uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/lodash": "^4.14.37",
     "@types/node": "^6.0.45",
     "@types/node-forge": "^0.6.5",
-    "@types/node-uuid": "0.0.28",
+    "@types/uuid": "2.0.29",
     "@types/xmldom": "^0.1.28",
     "deflate-js": "^0.2.3",
     "lodash": "^3.10.0",

--- a/src/binding-post.ts
+++ b/src/binding-post.ts
@@ -5,7 +5,7 @@
 */
 
 import { wording, tags, namespace } from './urn';
-import * as uuid from 'node-uuid';
+import * as uuid from 'uuid';
 import libsaml from './libsaml';
 import utility from './utility';
 

--- a/src/binding-redirect.ts
+++ b/src/binding-redirect.ts
@@ -8,7 +8,7 @@
 */
 import utility from './utility';
 import libsaml from './libsaml';
-import * as uuid from 'node-uuid';
+import * as uuid from 'uuid';
 import Entity from './entity';
 import { IdentityProvider as Idp } from './entity-idp';
 import { ServiceProvider as Sp } from './entity-sp';

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -8,7 +8,7 @@
 */
 import utility from './utility';
 import { namespace, wording, algorithms } from './urn';
-import * as uuid from 'node-uuid';
+import * as uuid from 'uuid';
 import libsaml from './libsaml';
 import Metadata from './metadata';
 import IdpMetadata from './metadata-idp';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,15 +10,15 @@
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-0.6.5.tgz#4ed3ea29b20ccca4e7cd778de0e039b01ddb3239"
 
-"@types/node-uuid@0.0.28":
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/@types/node-uuid/-/node-uuid-0.0.28.tgz#41655b5ce63b2f3374c4e826b4dd21e729058e3d"
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*", "@types/node@^6.0.45":
   version "6.0.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.45.tgz#c4842a9d653d767831e4ff495b6008cc0d579966"
+
+"@types/uuid@2.0.29":
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-2.0.29.tgz#939a198ab73567f811ab84f670d2be9c25addd41"
+  dependencies:
+    "@types/node" "*"
 
 "@types/xmldom":
   version "0.1.28"


### PR DESCRIPTION
Your package.json had `uuid` as a dependency, but your code requested `node-uuid`.
I changed it everywhere to be the newer `uuid` package. But I don't know if this is what you intended.

(btw, no idea why git shows merge conflicts on exactly the same lines).