### PR TITLE
Promisify (+ async/await)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ build
 
 #jetbrains IDEs
 .idea
+
+#vscode
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ build
 .yarnclean
 
 .nyc_output
+
+#jetbrains IDEs
+.idea

--- a/examples/idp/routes/sso.js
+++ b/examples/idp/routes/sso.js
@@ -112,7 +112,7 @@ router.get('/SingleSignOnService/:id', function (req, res) {
       return assoIdp.sendLoginResponse(targetSP, parseResult, 'post', req.user);
   })
   .then(response => {
-     res.render('actions', response);
+    res.render('actions', response);
   });
 });
 
@@ -123,9 +123,8 @@ router.post('/SingleSignOnService/:id', function (req, res) {
   assoIdp.parseLoginRequest(targetSP, 'post', req)
   .then(parseResult => {
     req.user.email = epn[req.user.sysEmail].app[req.params.id.toString()].assoSpEmail;
-    return assoIdp.sendLoginResponse(targetSP, parseResult, 'post', req.user);
-  })
-  .then(response => {
+    return assoIdp.sendLoginResponse(targetSP, parseResult, 'post', req.user);  
+  }).then(response => {
     res.render('actions', response);
   });
 });
@@ -181,13 +180,12 @@ router.get('/logout/all', function (req, res) {
     var assoIdp = entity.assoIdp;
     var targetSP = entity.targetSP;
     req.user.email = epn[req.user.sysEmail].app[id.toString()].assoSpEmail;
-    assoIdp.sendLogoutRequest(targetSP, 'post', req.user, relayState)
-    .then(response => {
-      if (req.query && req.query.async && req.query.async.toString() === 'true') {
-        response.ajaxSubmit = true;
-      }
-      return res.render('actions', response);
-    });
+    const response = assoIdp.sendLogoutRequest(targetSP, 'post', req.user, relayState)
+    if (req.query && req.query.async && req.query.async.toString() === 'true') {
+      response.ajaxSubmit = true;
+    }
+    return res.render('actions', response);
+ 
   } else {
     req.logout();
     req.flash('info', 'Unexpected error in /relayState');
@@ -200,10 +198,12 @@ router.get('/select/:id', function (req, res) {
   var assoIdp = entity.assoIdp;
   var targetSP = entity.targetSP;
   req.user.email = epn[req.user.sysEmail].app[req.params.id.toString()].assoSpEmail;
-  assoIdp.sendLoginResponse(targetSP, null, 'post', req.user).then(response => {
+  assoIdp.sendLoginResponse(targetSP, null, 'post', req.user)
+  .then(response => {
     response.title = 'POST data';
     res.render('actions', response);
   });
+  
 });
 
 module.exports = router;

--- a/examples/idp/routes/sso.js
+++ b/examples/idp/routes/sso.js
@@ -126,7 +126,12 @@ router.post('/SingleSignOnService/:id', function (req, res) {
     return assoIdp.sendLoginResponse(targetSP, parseResult, 'post', req.user);  
   }).then(response => {
     res.render('actions', response);
+  }).catch(err => {
+    res.render('error', {
+      message: err.message
+    });
   });
+
 });
 
 router.get('/SingleLogoutService/:id', function (req, res) {
@@ -136,14 +141,18 @@ router.get('/SingleLogoutService/:id', function (req, res) {
   assoIdp.parseLogoutResponse(targetSP, 'redirect', req)
     .then(parseResult => {
       if (req.query.RelayState) {
-      res.redirect(req.query.RelayState);
-    } else {
-      req.logout();
-      req.flash('info', 'All participating service provider has been logged out');
-      res.redirect('/login');
-    }
+        res.redirect(req.query.RelayState);
+      } else {
+        req.logout();
+        req.flash('info', 'All participating service provider has been logged out');
+        res.redirect('/login');
+      }
+    }).catch(err => {
+      res.render('error', {
+        message: err.message
+      });
     });
-});
+})
 
 router.post('/SingleLogoutService/:id', function (req, res) {
   var entity = entityPair(req.params.id);
@@ -159,6 +168,11 @@ router.post('/SingleLogoutService/:id', function (req, res) {
       req.flash('info', 'All participating service provider has been logged out');
       res.redirect('/login');
     }
+  })
+  .catch(err => {
+    res.render('error', {
+      message: err.message
+    });
   });
 });
 
@@ -202,6 +216,11 @@ router.get('/select/:id', function (req, res) {
   .then(response => {
     response.title = 'POST data';
     res.render('actions', response);
+  })
+  .catch(err => {
+    res.render('error', {
+      message: err.message
+    });
   });
   
 });

--- a/examples/idp/routes/sso.js
+++ b/examples/idp/routes/sso.js
@@ -106,11 +106,13 @@ router.get('/SingleSignOnService/:id', function (req, res) {
   var entity = entityPair(req.params.id);
   var assoIdp = entity.assoIdp;
   var targetSP = entity.targetSP;
-  assoIdp.parseLoginRequest(targetSP, 'redirect', req, function (parseResult) {
-    req.user.email = epn[req.user.sysEmail].app[req.params.id.toString()].assoSpEmail;
-    assoIdp.sendLoginResponse(targetSP, parseResult, 'post', req.user, function (response) {
-      res.render('actions', response);
-    });
+  assoIdp.parseLoginRequest(targetSP, 'redirect', req)
+  .then(parseResult => {
+      req.user.email = epn[req.user.sysEmail].app[req.params.id.toString()].assoSpEmail;
+      return assoIdp.sendLoginResponse(targetSP, parseResult, 'post', req.user);
+  })
+  .then(response => {
+     res.render('actions', response);
   });
 });
 
@@ -118,11 +120,13 @@ router.post('/SingleSignOnService/:id', function (req, res) {
   var entity = entityPair(req.params.id);
   var assoIdp = entity.assoIdp;
   var targetSP = entity.targetSP;
-  assoIdp.parseLoginRequest(targetSP, 'post', req, function (parseResult) {
+  assoIdp.parseLoginRequest(targetSP, 'post', req)
+  .then(parseResult => {
     req.user.email = epn[req.user.sysEmail].app[req.params.id.toString()].assoSpEmail;
-    assoIdp.sendLoginResponse(targetSP, parseResult, 'post', req.user, function (response) {
-      res.render('actions', response);
-    });
+    return assoIdp.sendLoginResponse(targetSP, parseResult, 'post', req.user);
+  })
+  .then(response => {
+    res.render('actions', response);
   });
 });
 
@@ -130,22 +134,24 @@ router.get('/SingleLogoutService/:id', function (req, res) {
   var entity = entityPair(req.params.id);
   var assoIdp = entity.assoIdp;
   var targetSP = entity.targetSP;
-  assoIdp.parseLogoutResponse(targetSP, 'redirect', req, function (parseResult) {
-    if (req.query.RelayState) {
+  assoIdp.parseLogoutResponse(targetSP, 'redirect', req)
+    .then(parseResult => {
+      if (req.query.RelayState) {
       res.redirect(req.query.RelayState);
     } else {
       req.logout();
       req.flash('info', 'All participating service provider has been logged out');
       res.redirect('/login');
     }
-  });
+    });
 });
 
 router.post('/SingleLogoutService/:id', function (req, res) {
   var entity = entityPair(req.params.id);
   var assoIdp = entity.assoIdp;
   var targetSP = entity.targetSP;
-  assoIdp.parseLogoutResponse(targetSP, 'post', req, function (parseResult) {
+  assoIdp.parseLogoutResponse(targetSP, 'post', req)
+  .then(parseResult => {
     if (req.body.RelayState) {
       res.redirect(req.body.RelayState);
     } else {
@@ -175,7 +181,8 @@ router.get('/logout/all', function (req, res) {
     var assoIdp = entity.assoIdp;
     var targetSP = entity.targetSP;
     req.user.email = epn[req.user.sysEmail].app[id.toString()].assoSpEmail;
-    assoIdp.sendLogoutRequest(targetSP, 'post', req.user, relayState, function (response) {
+    assoIdp.sendLogoutRequest(targetSP, 'post', req.user, relayState)
+    .then(response => {
       if (req.query && req.query.async && req.query.async.toString() === 'true') {
         response.ajaxSubmit = true;
       }
@@ -193,7 +200,7 @@ router.get('/select/:id', function (req, res) {
   var assoIdp = entity.assoIdp;
   var targetSP = entity.targetSP;
   req.user.email = epn[req.user.sysEmail].app[req.params.id.toString()].assoSpEmail;
-  assoIdp.sendLoginResponse(targetSP, null, 'post', req.user, function (response) {
+  assoIdp.sendLoginResponse(targetSP, null, 'post', req.user).then(response => {
     response.title = 'POST data';
     res.render('actions', response);
   });

--- a/examples/sp1/routes/sso.js
+++ b/examples/sp1/routes/sso.js
@@ -79,17 +79,15 @@ router.get('/spinitsso-post', function (req, res) {
       break;
     }
   }
-  fromSP.sendLoginRequest(toIdP, 'post')
-  .then(request => {
-    res.render('actions', request);
-  });
+  console.log("WTF2");
+  const request = fromSP.sendLoginRequest(toIdP, 'post')
+  res.render('actions', request);
+
 });
 
 router.get('/spinitsso-redirect', function (req, res) {
-  sp.sendLoginRequest(idp, 'redirect')
-  .then(url => {
-    res.redirect(url);
-  });
+  const url = sp.sendLoginRequest(idp, 'redirect');
+  res.redirect(url);
 });
 
 router.post('/acs/:idp?', function (req, res, next) {
@@ -120,11 +118,10 @@ function slo (req, res, binding, relayState) {
     .then(parseResult => {
       // Check before logout
       req.logout();
-      return sp.sendLogoutResponse(idp, parseResult, 'redirect', relayState);
-    })
-    .then(url => {
+      const url = sp.sendLogoutResponse(idp, parseResult, 'redirect', relayState);
       res.redirect(url);
     })
+
 }
 
 router.post('/slo', function (req, res) {

--- a/examples/sp1/routes/sso.js
+++ b/examples/sp1/routes/sso.js
@@ -79,7 +79,7 @@ router.get('/spinitsso-post', function (req, res) {
       break;
     }
   }
-  console.log("WTF2");
+
   const request = fromSP.sendLoginRequest(toIdP, 'post')
   res.render('actions', request);
 
@@ -99,7 +99,8 @@ router.post('/acs/:idp?', function (req, res, next) {
     _idp = idp;
     _sp = sp;
   }
-  _sp.parseLoginResponse(_idp, 'post', req).then(parseResult => {
+  _sp.parseLoginResponse(_idp, 'post', req)
+  .then(parseResult => {
     if (parseResult.extract.nameid) {
       res.render('login', {
         title: 'Processing',
@@ -110,6 +111,11 @@ router.post('/acs/:idp?', function (req, res, next) {
       req.flash('info', 'Unexpected error');
       res.redirect('/login');
     }
+  })
+  .catch(err => {
+    res.render('error', {
+      message: err.message
+    });
   });
 });
 
@@ -121,6 +127,11 @@ function slo (req, res, binding, relayState) {
       const url = sp.sendLogoutResponse(idp, parseResult, 'redirect', relayState);
       res.redirect(url);
     })
+    .catch(err => {
+      res.render('error', {
+        message: err.message
+      });
+    });
 
 }
 

--- a/examples/sp2/routes/sso.js
+++ b/examples/sp2/routes/sso.js
@@ -41,6 +41,11 @@ router.post('/acs', function (req, res, next) {
     } else {
       res.redirect('/login');
     }
+  })
+  .catch(err => {
+    res.render('error', {
+      message: err.message
+    });
   });
 });
 
@@ -50,6 +55,11 @@ function slo (req, res, binding, relayState) {
       req.logout();
       const url = sp.sendLogoutResponse(idp, parseResult, 'redirect', relayState);
       res.redirect(url);
+    })
+    .catch(err => {
+      res.render('error', {
+        message: err.message
+      });
     });
 }
 

--- a/examples/sp2/routes/sso.js
+++ b/examples/sp2/routes/sso.js
@@ -20,17 +20,13 @@ router.get('/metadata', function (req, res, next) {
 });
 
 router.get('/spinitsso-post', function (req, res) {
-  sp.sendLoginRequest(idp, 'post')
-  .then(request => {
-    res.render('actions', request);
-  });
+  const request = sp.sendLoginRequest(idp, 'post');
+  res.render('actions', request);
 });
 
 router.get('/spinitsso-redirect', function (req, res) {
-  sp.sendLoginRequest(idp, 'redirect')
-  .then(url => {
-    res.redirect(url);
-  });
+  const url = sp.sendLoginRequest(idp, 'redirect');
+  res.redirect(url);
 });
 
 router.post('/acs', function (req, res, next) {
@@ -52,11 +48,9 @@ function slo (req, res, binding, relayState) {
   sp.parseLogoutRequest(idp, binding, req)
     .then(parseResult => {
       req.logout();
-      return sp.sendLogoutResponse(idp, parseResult, 'redirect', relayState);
-    })
-    .then(url => {
+      const url = sp.sendLogoutResponse(idp, parseResult, 'redirect', relayState);
       res.redirect(url);
-    })
+    });
 }
 
 router.post('/slo', function (req, res) {

--- a/src/binding-post.ts
+++ b/src/binding-post.ts
@@ -59,7 +59,7 @@ function base64LoginRequest(referenceTagXPath: string, entity: any, rcallback: (
 * @param  {object} user                        current logged user (e.g. req.user)
 * @param  {function} rcallback     used when developers have their own login response template
 */
-function base64LoginResponse(requestInfo: any, referenceTagXPath: string, entity: any, user: any, rcallback: (template: string) => string, rtnCallback: (xmlStr: any) => void) {
+async function base64LoginResponse(requestInfo: any, referenceTagXPath: string, entity: any, user: any, rcallback: (template: string) => string) {
   let metadata = {
     idp: entity.idp.entityMeta,
     sp: entity.sp.entityMeta
@@ -107,7 +107,11 @@ function base64LoginResponse(requestInfo: any, referenceTagXPath: string, entity
     }
     resXml = metadata.sp.isWantAssertionsSigned() ? libsaml.constructSAMLSignature(rawSamlResponse, referenceTagXPath, metadata.idp.getX509Certificate('signing'), idpSetting.privateKeyFile, idpSetting.privateKeyFilePass, idpSetting.requestSignatureAlgorithm, false) : rawSamlResponse; // SS1.1 add signature algorithm
     // SS-1.1
-    idpSetting.isAssertionEncrypted ? libsaml.encryptAssertion(entity.idp, entity.sp, resXml, rtnCallback) : rtnCallback(resXml);
+    if( idpSetting.isAssertionEncrypted ) {
+      return await libsaml.encryptAssertion(entity.idp, entity.sp, resXml)
+    }else{
+      return resXml
+    }
   } else {
     throw new Error('Missing declaration of metadata');
   }

--- a/src/entity-idp.ts
+++ b/src/entity-idp.ts
@@ -62,47 +62,47 @@ export class IdentityProvider extends Entity {
   * @param  {object}   user                      current logged user (e.g. req.user)
   * @param  {function} rcallback                 used when developers have their own login response template
   */
-	public async sendLoginResponse(sp, requestInfo, binding, user, rcallback) {
-		const protocol = namespace.binding[binding] || namespace.binding.redirect;
-		if (protocol == namespace.binding.post) {
-			const res = await postBinding.base64LoginResponse(requestInfo, libsaml.createXPath('Assertion'), {
-				idp: this,
-				sp: sp
-			}, user, rcallback);
+  public async sendLoginResponse(sp, requestInfo, binding, user, rcallback) {
+    const protocol = namespace.binding[binding] || namespace.binding.redirect;
+    if (protocol == namespace.binding.post) {
+      const res = await postBinding.base64LoginResponse(requestInfo, libsaml.createXPath('Assertion'), {
+        idp: this,
+        sp: sp
+      }, user, rcallback);
 
-			// xmlenc is using async process
-			return {
-				actionValue: res,
-				entityEndpoint: sp.entityMeta.getAssertionConsumerService(binding),
-				actionType: 'SAMLResponse'
-			};
+      // xmlenc is using async process
+      return {
+        actionValue: res,
+        entityEndpoint: sp.entityMeta.getAssertionConsumerService(binding),
+        actionType: 'SAMLResponse'
+      };
 
-		} else {
-			// Will support arifact in the next release
-			throw new Error('This binding is not support');
-		}
-	}
+    } else {
+      // Will support arifact in the next release
+      throw new Error('This binding is not support');
+    }
+  }
   /**
   * @desc   Validation of the parsed URL parameters
   * @param  {ServiceProvider}   sp               object of service provider
   * @param  {string}   binding                   protocol binding
   * @param  {request}   req                      request
   */
-	public parseLoginRequest(sp, binding, req) {
-		return this.abstractBindingParser({
-			parserFormat: ['AuthnContextClassRef', 'Issuer', {
-				localName: 'Signature',
-				extractEntireBody: true
-			}, {
-					localName: 'AuthnRequest',
-					attributes: ['ID']
-				}, {
-					localName: 'NameIDPolicy',
-					attributes: ['Format', 'AllowCreate']
-				}],
-			checkSignature: this.entityMeta.isWantAuthnRequestsSigned(),
-			parserType: 'SAMLRequest',
-			actionType: 'login'
-		}, binding, req, sp.entityMeta);
-	};
+  public parseLoginRequest(sp, binding, req) {
+    return this.abstractBindingParser({
+      parserFormat: ['AuthnContextClassRef', 'Issuer', {
+        localName: 'Signature',
+        extractEntireBody: true
+      }, {
+          localName: 'AuthnRequest',
+          attributes: ['ID']
+        }, {
+          localName: 'NameIDPolicy',
+          attributes: ['Format', 'AllowCreate']
+        }],
+      checkSignature: this.entityMeta.isWantAuthnRequestsSigned(),
+      parserType: 'SAMLRequest',
+      actionType: 'login'
+    }, binding, req, sp.entityMeta);
+  };
 }

--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -45,7 +45,7 @@ export class ServiceProvider extends Entity {
   * @param  {string}   binding                   protocol binding
   * @param  {function} rcallback     used when developers have their own login response template
   */
-	public sendLoginRequest(idp, binding, rcallback) {
+	public sendLoginRequest(idp, binding, rcallback) : any {
 		const protocol = namespace.binding[binding] || namespace.binding.redirect;
 		if (protocol == namespace.binding.redirect) {
 			return redirectBinding.loginRequestRedirectURL({

--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -40,65 +40,63 @@ export class ServiceProvider extends Entity {
     super(entitySetting, 'sp');
   }
   /**
-  * @desc  Generates the login request and callback to developers to design their own method
+  * @desc  Generates the login request for developers to design their own method
   * @param  {IdentityProvider} idp               object of identity provider
   * @param  {string}   binding                   protocol binding
-  * @param  {function} callback                  developers do their own request to do with passing information
   * @param  {function} rcallback     used when developers have their own login response template
   */
-  public sendLoginRequest(idp, binding, callback, rcallback) {
-    const protocol = namespace.binding[binding] || namespace.binding.redirect;
-    if (protocol == namespace.binding.redirect) {
-      return callback(redirectBinding.loginRequestRedirectURL({
-        idp: idp,
-        sp: this
-      }, rcallback));
-    } else if (protocol == namespace.binding.post) {
-      return callback({
-        actionValue: postBinding.base64LoginRequest(libsaml.createXPath('Issuer'), {
-          idp: idp,
-          sp: this
-        }, rcallback),
-        relayState: this.entitySetting.relayState,
-        entityEndpoint: idp.entityMeta.getSingleSignOnService(binding),
-        actionType: 'SAMLRequest'
-      });
-    } else {
-      // Will support arifact in the next release
-      throw new Error('The binding is not support');
-    }
-  }
+	public sendLoginRequest(idp, binding, rcallback) {
+		const protocol = namespace.binding[binding] || namespace.binding.redirect;
+		if (protocol == namespace.binding.redirect) {
+			return redirectBinding.loginRequestRedirectURL({
+				idp: idp,
+				sp: this
+			}, rcallback);
+		} else if (protocol == namespace.binding.post) {
+			return {
+				actionValue: postBinding.base64LoginRequest(libsaml.createXPath('Issuer'), {
+					idp: idp,
+					sp: this
+				}, rcallback),
+				relayState: this.entitySetting.relayState,
+				entityEndpoint: idp.entityMeta.getSingleSignOnService(binding),
+				actionType: 'SAMLRequest'
+			};
+		} else {
+			// Will support arifact in the next release
+			throw new Error('The binding is not support');
+		}
+	}
   /**
-  * @desc   Validation and callback parsed the URL parameters
+  * @desc   Validation of the parsed the URL parameters
   * @param  {IdentityProvider}   idp             object of identity provider
   * @param  {string}   binding                   protocol binding
   * @param  {request}   req                      request
-  * @param  {function} parseCallback             developers use their own validation to do with passing information
   */
-  public parseLoginResponse(idp, binding, req, parseCallback) {
-    return this.abstractBindingParser({
-      parserFormat: [{
-        localName: 'StatusCode',
-        attributes: ['Value']
-      }, {
-        localName: 'Conditions',
-        attributes: ['NotBefore', 'NotOnOrAfter']
-      }, 'Audience', 'Issuer', 'NameID', {
-        localName: 'Signature',
-        extractEntireBody: true
-      }, {
-        localName: {
-          tag: 'Attribute',
-          key: 'Name'
-        },
-        valueTag: 'AttributeValue'
-      }],
-      checkSignature: this.entityMeta.isWantAssertionsSigned(),
-      from: idp,
-      supportBindings: ['post'],
-      parserType: 'SAMLResponse',
-      actionType: 'login'
-    }, binding, req, idp.entityMeta, parseCallback);
-  };
+	public parseLoginResponse(idp, binding, req) {
+		return this.abstractBindingParser({
+			parserFormat: [{
+				localName: 'StatusCode',
+				attributes: ['Value']
+			}, {
+				localName: 'Conditions',
+				attributes: ['NotBefore', 'NotOnOrAfter']
+			}, 'Audience', 'Issuer', 'NameID', {
+				localName: 'Signature',
+				extractEntireBody: true
+			}, {
+				localName: {
+					tag: 'Attribute',
+					key: 'Name'
+				},
+				valueTag: 'AttributeValue'
+			}],
+			checkSignature: this.entityMeta.isWantAssertionsSigned(),
+			from: idp,
+			supportBindings: ['post'],
+			parserType: 'SAMLResponse',
+			actionType: 'login'
+		}, binding, req, idp.entityMeta);
+	};
 
 }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -202,7 +202,7 @@ export default class Entity {
 		if (binding == bindDict.post && supportBindings.indexOf(nsBinding[binding]) !== -1) {
 			// make sure express.bodyParser() has been used
 			let encodedRequest = req.body[libsaml.getQueryParamByType(parserType)];
-			let decodedRequest = utility.base64Decode(encodedRequest);
+			let decodedRequest = String(utility.base64Decode(encodedRequest));
 			let issuer = targetEntityMetadata.getEntityID();
 			//SS-1.1
 			const res = await libsaml.decryptAssertion(parserType, here, from, decodedRequest);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -133,16 +133,15 @@ export default class Entity {
   * @param  {string} binding is the protocol bindings (e.g. redirect, post)
   * @param  {request} req is the http request
   * @param  {Metadata} targetEntityMetadata either IDP metadata or SP metadata
-  * @param  {function} parseCallback is the callback function with extracted parameter
-  * @return {function} parseCallback
+  * @return {ParseResult} parseResult
   */
-  abstractBindingParser(opts, binding: string, req, targetEntityMetadata, parseCallback) {
-    const here = this; //SS-1.1 (refractor later on)
-    const entityMeta: any = this.entityMeta;
-    let options = opts || {};
-    let parseResult = {};
-    let supportBindings = [nsBinding.redirect, nsBinding.post];
-    let { parserFormat: fields, parserType, actionType, from, checkSignature = true, decryptAssertion = true } = options;
+	async abstractBindingParser(opts, binding: string, req, targetEntityMetadata) {
+		const here = this; //SS-1.1 (refractor later on)
+		const entityMeta: any = this.entityMeta;
+		let options = opts || {};
+		let parseResult = {};
+		let supportBindings = [nsBinding.redirect, nsBinding.post];
+		let { parserFormat: fields, parserType, actionType, from, checkSignature = true, decryptAssertion = true } = options;
 
     if (actionType === 'login') {
       if (entityMeta.getAssertionConsumerService) {
@@ -169,169 +168,169 @@ export default class Entity {
       let reqQuery: { SigAlg: string, Signature: string } = req.query;
       let samlContent = reqQuery[libsaml.getQueryParamByType(parserType)];
 
-      if (samlContent === undefined) {
-        throw new Error('Bad request');
-      }
-      let xmlString = utility.inflateString(decodeURIComponent(samlContent));
-      if (checkSignature) {
-        let { SigAlg: sigAlg, Signature: signature } = reqQuery;
-        if (signature && sigAlg) {
-          // add sigAlg to verify message (SS-1.1)
-          if (libsaml.verifyMessageSignature(targetEntityMetadata, <string>req._parsedOriginalUrl.query.split('&Signature=')[0], new Buffer(decodeURIComponent(signature), 'base64'), sigAlg)) {
-            parseResult = {
-              samlContent: xmlString,
-              sigAlg: decodeURIComponent(sigAlg),
-              extract: libsaml.extractor(xmlString, fields)
-            };
-          } else {
-            // Fail to verify message signature
-            throw new Error('fail to verify message signature');
-          }
-        } else {
-          // Missing signature or signature algorithm
-          throw new Error('missing signature or signature algorithm');
-        }
-      } else {
-        parseResult = {
-          samlContent: xmlString,
-          extract: libsaml.extractor(xmlString, fields)
-        };
-      }
-      return parseCallback(parseResult);
-    }
+			if (samlContent === undefined) {
+				throw new Error('Bad request');
+			}
+			let xmlString = utility.inflateString(decodeURIComponent(samlContent));
+			if (checkSignature) {
+				let { SigAlg: sigAlg, Signature: signature } = reqQuery;
+				if (signature && sigAlg) {
+					// add sigAlg to verify message (SS-1.1)
+					if (libsaml.verifyMessageSignature(targetEntityMetadata, <string>req._parsedOriginalUrl.query.split('&Signature=')[0], new Buffer(decodeURIComponent(signature), 'base64'), sigAlg)) {
+						parseResult = {
+							samlContent: xmlString,
+							sigAlg: decodeURIComponent(sigAlg),
+							extract: libsaml.extractor(xmlString, fields)
+						};
+					} else {
+						// Fail to verify message signature
+						throw new Error('fail to verify message signature');
+					}
+				} else {
+					// Missing signature or signature algorithm
+					throw new Error('missing signature or signature algorithm');
+				}
+			} else {
+				parseResult = {
+					samlContent: xmlString,
+					extract: libsaml.extractor(xmlString, fields)
+				};
+			}
+			return parseResult;
+		}
 
-    if (binding == bindDict.post && supportBindings.indexOf(nsBinding[binding]) !== -1) {
-      // make sure express.bodyParser() has been used
-      let encodedRequest = req.body[libsaml.getQueryParamByType(parserType)];
-      let decodedRequest = utility.base64Decode(encodedRequest);
-      let issuer = targetEntityMetadata.getEntityID();
-      //SS-1.1
-      return libsaml.decryptAssertion(parserType, here, from, decodedRequest, res => {
-        let parseResult = {
-          samlContent: res,
-          extract: libsaml.extractor(res, fields)
-        };
-        if (checkSignature) {
-          // verify the signature
-          if (!libsaml.verifySignature(res, parseResult.extract.signature, {
-            cert: targetEntityMetadata,
-            signatureAlgorithm: here.entitySetting.requestSignatureAlgorithm
-          })) {
-            throw new Error('incorrect signature');
-          }
-        }
-        if (!here.verifyFields(parseResult.extract.issuer, issuer)) {
-          throw new Error('incorrect issuer');
-        }
-        return parseCallback(parseResult);
-      });
-    }
-    // Will support arifact in the next release
-    throw new Error('this binding is not support');
-  };
+		if (binding == bindDict.post && supportBindings.indexOf(nsBinding[binding]) !== -1) {
+			// make sure express.bodyParser() has been used
+			let encodedRequest = req.body[libsaml.getQueryParamByType(parserType)];
+			let decodedRequest = utility.base64Decode(encodedRequest);
+			let issuer = targetEntityMetadata.getEntityID();
+			//SS-1.1
+			const res = await libsaml.decryptAssertion(parserType, here, from, decodedRequest);
 
-  /** @desc   Generates the logout request and callback to developers to design their own method
+			let parseResult = {
+				samlContent: res,
+				extract: libsaml.extractor(res, fields)
+			};
+			if (checkSignature) {
+				// verify the signature
+				if (!libsaml.verifySignature(res, parseResult.extract.signature, {
+					cert: targetEntityMetadata,
+					signatureAlgorithm: here.entitySetting.requestSignatureAlgorithm
+				})) {
+					throw new Error('incorrect signature');
+				}
+			}
+			if (!here.verifyFields(parseResult.extract.issuer, issuer)) {
+				throw new Error('incorrect issuer');
+			}
+
+			return parseResult;
+
+		}
+		// Will support arifact in the next release
+		throw new Error('this binding is not support');
+	};
+
+  /** @desc   Generates the logout request for developers to design their own method
   * @param  {ServiceProvider} sp     object of service provider
   * @param  {string}   binding       protocol binding
   * @param  {object}   user          current logged user (e.g. req.user)
   * @param  {string} relayState      the URL to which to redirect the user when logout is complete
-  * @param  {function} callback      developers do their own request to do with passing information
   * @param  {function} rcallback     used when developers have their own login response template
   */
-  sendLogoutRequest(targetEntity, binding, user, relayState, callback, rcallback) {
-    if (binding === wording.binding.redirect) {
-      return callback(redirectBinding.logoutRequestRedirectURL(user, {
-        init: this,
-        target: targetEntity
-      }, rcallback, relayState));
-    }
-    if (binding === wording.binding.post) {
-      const entityEndpoint = targetEntity.entityMeta.getSingleLogoutService(binding);
-      const	actionValue = postBinding.base64LogoutRequest(user, libsaml.createXPath('Issuer'), { init: this, target: targetEntity }, rcallback);
-      return callback({
-        actionValue,
-        relayState,
-        entityEndpoint,
-        actionType: 'SAMLRequest'
-      });
-    }
-    // Will support arifact in the next release
-    throw new Error('The binding is not support');
-  }
+	sendLogoutRequest(targetEntity, binding, user, relayState, rcallback) {
+		if (binding === wording.binding.redirect) {
+			return redirectBinding.logoutRequestRedirectURL(user, {
+				init: this,
+				target: targetEntity
+			}, rcallback, relayState);
+		}
+		if (binding === wording.binding.post) {
+			const entityEndpoint = targetEntity.entityMeta.getSingleLogoutService(binding);
+			const	actionValue = postBinding.base64LogoutRequest(user, libsaml.createXPath('Issuer'), { init: this, target: targetEntity }, rcallback);
+			return {
+				actionValue,
+				relayState,
+				entityEndpoint,
+				actionType: 'SAMLRequest'
+			};
+		}
+		// Will support arifact in the next release
+		throw new Error('The binding is not support');
+	}
   /**
-  * @desc  Generates the logout response and callback to developers to design their own method
+  * @desc  Generates the logout response for developers to design their own method
   * @param  {IdentityProvider} idp               object of identity provider
   * @param  {object} requestInfo                 corresponding request, used to obtain the id
   * @param  {string} relayState                  the URL to which to redirect the user when logout is complete.
   * @param  {string} binding                     protocol binding
-  * @param  {function} callback                  developers use their own form submit to do with passing information
   * @param  {function} rcallback                 used when developers have their own login response template
   */
-  sendLogoutResponse(targetEntity, requestInfo, binding, relayState, callback, rcallback) {
-    binding = namespace.binding[binding] || namespace.binding.redirect;
-    if (binding === namespace.binding.redirect) {
-      return callback(redirectBinding.logoutResponseRedirectURL(requestInfo, {
-        init: this,
-        target: targetEntity
-      }, relayState, rcallback));
-    }
-    if (binding === namespace.binding.post) {
-      return callback({
-        actionValue: postBinding.base64LogoutResponse(requestInfo, libsaml.createXPath('Issuer'), {
-          init: this,
-          target: targetEntity
-        }, rcallback),
-        relayState: relayState,
-        entityEndpoint: targetEntity.entityMeta.getSingleLogoutService(binding),
-        actionType: 'SAMLResponse'
-      });
-    }
-    throw new Error('This binding is not support');
-  }
+	sendLogoutResponse(targetEntity, requestInfo, binding, relayState, rcallback) {
+		binding = namespace.binding[binding] || namespace.binding.redirect;
+		if (binding === namespace.binding.redirect) {
+			return redirectBinding.logoutResponseRedirectURL(requestInfo, {
+				init: this,
+				target: targetEntity
+			}, relayState, rcallback);
+		}
+		if (binding === namespace.binding.post) {
+			return {
+				actionValue: postBinding.base64LogoutResponse(requestInfo, libsaml.createXPath('Issuer'), {
+					init: this,
+					target: targetEntity
+				}, rcallback),
+				relayState: relayState,
+				entityEndpoint: targetEntity.entityMeta.getSingleLogoutService(binding),
+				actionType: 'SAMLResponse'
+			};
+		}
+		throw new Error('This binding is not support');
+	}
   /**
-  * @desc   Validation and callback parsed the URL parameters
+  * @desc   Validation of the parsed the URL parameters
   * @param  {IdentityProvider}   idp             object of identity provider
   * @param  {string}   binding                   protocol binding
   * @param  {request}   req                      request
-  * @param  {function} parseCallback             developers use their own validation to do with passing information
+	* @return {Promise}
   */
-  parseLogoutRequest(targetEntity, binding, req, parseCallback) {
-    return this.abstractBindingParser({
-      parserFormat: ['NameID', 'Issuer', {
-        localName: 'Signature',
-        extractEntireBody: true
-      }, {
-          localName: 'LogoutRequest',
-          attributes: ['ID', 'Destination']
-        }],
-      checkSignature: this.entitySetting.wantLogoutRequestSigned,
-      parserType: 'LogoutRequest',
-      actionType: 'logout'
-    }, binding, req, targetEntity.entityMeta, parseCallback);
-  };
+	parseLogoutRequest(targetEntity, binding, req) {
+		return this.abstractBindingParser({
+			parserFormat: ['NameID', 'Issuer', {
+				localName: 'Signature',
+				extractEntireBody: true
+			}, {
+					localName: 'LogoutRequest',
+					attributes: ['ID', 'Destination']
+				}],
+			checkSignature: this.entitySetting.wantLogoutRequestSigned,
+			parserType: 'LogoutRequest',
+			actionType: 'logout'
+		}, binding, req, targetEntity.entityMeta);
+	};
   /**
-  * @desc   Validation and callback parsed the URL parameters
+  * @desc   Validation of the parsed the URL parameters
   * @param  {string}   binding                   protocol binding
   * @param  {request}   req                      request
   * @param  {ServiceProvider}   sp               object of service provider
-  * @param  {function} parseCallback             developers use their own validation to do with passing information
+	* @return {Promise}
   */
-  parseLogoutResponse(targetEntity, binding, req, parseCallback) {
-    return this.abstractBindingParser({
-      parserFormat: [{
-        localName: 'StatusCode',
-        attributes: ['Value']
-      }, 'Issuer', {
-        localName: 'Signature',
-        extractEntireBody: true
-      }, {
-        localName: 'LogoutResponse',
-        attributes: ['ID', 'Destination', 'InResponseTo']
-      }],
-      checkSignature: this.entitySetting.wantLogoutResponseSigned,
-      supportBindings: ['post'],
-      parserType: 'LogoutResponse',
-      actionType: 'logout'
-    }, binding, req, targetEntity.entityMeta, parseCallback);
-  }
+	parseLogoutResponse(targetEntity, binding, req) {
+		return this.abstractBindingParser({
+			parserFormat: [{
+				localName: 'StatusCode',
+				attributes: ['Value']
+			}, 'Issuer', {
+				localName: 'Signature',
+				extractEntireBody: true
+			}, {
+				localName: 'LogoutResponse',
+				attributes: ['ID', 'Destination', 'InResponseTo']
+			}],
+			checkSignature: this.entitySetting.wantLogoutResponseSigned,
+			supportBindings: ['post'],
+			parserType: 'LogoutResponse',
+			actionType: 'logout'
+		}, binding, req, targetEntity.entityMeta);
+	}
 }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -238,7 +238,7 @@ export default class Entity {
   * @param  {string} relayState      the URL to which to redirect the user when logout is complete
   * @param  {function} rcallback     used when developers have their own login response template
   */
-  sendLogoutRequest(targetEntity, binding, user, relayState, rcallback) {
+  sendLogoutRequest(targetEntity, binding, user, relayState, rcallback) : any {
     if (binding === wording.binding.redirect) {
       return redirectBinding.logoutRequestRedirectURL(user, {
         init: this,
@@ -266,7 +266,7 @@ export default class Entity {
   * @param  {string} binding                     protocol binding
   * @param  {function} rcallback                 used when developers have their own login response template
   */
-  sendLogoutResponse(targetEntity, requestInfo, binding, relayState, rcallback) {
+  sendLogoutResponse(targetEntity, requestInfo, binding, relayState, rcallback) : any {
     binding = namespace.binding[binding] || namespace.binding.redirect;
     if (binding === namespace.binding.redirect) {
       return redirectBinding.logoutResponseRedirectURL(requestInfo, {

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -527,7 +527,7 @@ const libSaml = function () {
 		* @param {string} entireXML         response in xml string format
 		* @return {function} a promise to get back the entire xml with decrypted assertion
 		*/
-		decryptAssertion: function (type: string, here, from, entireXML: string | Buffer) {
+		decryptAssertion: function (type: string, here, from, entireXML: string) {
 			return new Promise<string>((resolve,reject) => {
 				// Implement decryption first then check the signature
 				if (entireXML) {

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -32,18 +32,18 @@ interface ExtractorResultInterface {
 }
 
 export interface LibSamlInterface {
-  getQueryParamByType: (type: string) => string;
-  createXPath: (local, isExtractAll?: boolean) => string;
-  replaceTagsByValue: (rawXML: string, tagValues: { any }) => string;
-  constructSAMLSignature: (xmlString: string, referenceXPath: string, x509: string, keyFile: string, passphrase: string, signatureAlgorithm: string, isBase64Output?: boolean) => string;
-  verifySignature: (xml: string, signature, opts) => boolean;
-  extractor: (xmlString: string, fields) => ExtractorResultInterface;
-  createKeySection: (use: string, certFile: string) => {};
-  constructMessageSignature: (octetString: string, keyFile: string, passphrase: string, isBase64?: boolean, signingAlgorithm?: string) => string;
-  verifyMessageSignature: (metadata, octetString: string, signature: string | Buffer, verifyAlgorithm: string) => boolean;
-  getKeyInfo: (x509Certificate: string) => void;
-  encryptAssertion: (sourceEntity, targetEntity, entireXML: string, callback) => void;
-  decryptAssertion: (type: string, here, from, entireXML: string, callback) => void;
+	getQueryParamByType: (type: string) => string;
+	createXPath: (local, isExtractAll?: boolean) => string;
+	replaceTagsByValue: (rawXML: string, tagValues: { any }) => string;
+	constructSAMLSignature: (xmlString: string, referenceXPath: string, x509: string, keyFile: string, passphrase: string, signatureAlgorithm: string, isBase64Output?: boolean) => string;
+	verifySignature: (xml: string, signature, opts) => boolean;
+	extractor: (xmlString: string, fields) => ExtractorResultInterface;
+	createKeySection: (use: string, certFile: string) => {};
+	constructMessageSignature: (octetString: string, keyFile: string, passphrase: string, isBase64?: boolean, signingAlgorithm?: string) => string;
+	verifyMessageSignature: (metadata, octetString: string, signature: string | Buffer, verifyAlgorithm: string) => boolean;
+	getKeyInfo: (x509Certificate: string) => void;
+	encryptAssertion: (sourceEntity, targetEntity, entireXML: string) => Promise<string>;
+	decryptAssertion: (type: string, here, from, entireXML: string) => Promise<string>;
 
   getSigningScheme: (sigAlg: string) => string | null;
   getDigestMethod: (sigAlg: string) => string | null;
@@ -379,184 +379,188 @@ const libSaml = function () {
           let attributes = field.attributes || [];
           let customKey = field.customKey || '';
 
-          if (typeof localName === 'string') {
-            objKey = localName;
-            if (extractEntireBody) {
-              res = getEntireBody(doc, localName);
-            } else {
-              if (attributes.length !== 0) {
-                res = getAttributes(doc, localName, attributes);
-              } else {
-                res = getInnerText(doc, localName);
-              }
-            }
-          } else {
-            objKey = localName.tag;
-            if (field.attributeTag) {
-              res = getAttributeKey(doc, objKey, localName.key, field.attributeTag);
-            } else if (field.valueTag) {
-              res = getInnerTextWithOuterKey(doc, objKey, localName.key, field.valueTag);
-            }
-          }
-          meta[customKey === '' ? objKey.toLowerCase() : customKey] = res;
-        }
-      });
-      return <ExtractorResultInterface>meta;
-    },
-    /**
-    * @desc Helper function to create the key section in metadata (abstraction for signing and encrypt use)
-    * @param  {string} use          type of certificate (e.g. signing, encrypt)
-    * @param  {string} certFile     declares the .cer file (e.g. path/certificate.cer)
-    * @return {object} object used in xml module
-    */
-    createKeySection: function (use: string, certFile: string) {
-      return {
-        KeyDescriptor: [{
-          _attr: { use }
-        }, {
-          KeyInfo: [{
-            _attr: {
-              'xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#'
-            }
-          }, {
-            X509Data: [{
-              X509Certificate: utility.parseCerFile(certFile)
-            }]
-          }]
-        }]
-      };
-    },
-    /**
-    * @desc Constructs SAML message
-    * @param  {string} octetString               see "Bindings for the OASIS Security Assertion Markup Language (SAML V2.0)" P.17/46
-    * @param  {string} keyFile                   declares the .pem file storing the private key (e.g. path/privkey.pem)
-    * @param  {string} passphrase                passphrase of .pem file [optional]
-    * @param  {string} signingAlgorithm          signing algorithm (SS-1.1)
-    * @return {string} message signature
-    */
-    constructMessageSignature: function (octetString: string, keyFile: string, passphrase: string, isBase64: boolean, signingAlgorithm: string) {
-      // Default returning base64 encoded signature
-      // Embed with node-rsa module
-      let key = new nrsa(utility.readPrivateKeyFromFile(keyFile, passphrase), {
-        signingScheme: getSigningScheme(signingAlgorithm) // SS-1.1
-      });
-      let signature = key.sign(octetString);
-      // Use private key to sign data
-      return isBase64 !== false ? signature.toString('base64') : signature;
-    },
-    /**
-    * @desc Verifies message signature
-    * @param  {Metadata} metadata                 metadata object of identity provider or service provider
-    * @param  {string} octetString                see "Bindings for the OASIS Security Assertion Markup Language (SAML V2.0)" P.17/46
-    * @param  {string} signature                  context of XML signature
-    * @param  {string} verifyAlgorithm            algorithm used to verify (SS-1.1)
-    * @return {boolean} verification result
-    *
-    * SS1.1 Code refractoring
-    */
-    verifyMessageSignature: function (metadata, octetString: string, signature: string | Buffer, verifyAlgorithm: string) {
-      let key = new nrsa(utility.getPublicKeyPemFromCertificate(metadata.getX509Certificate(certUsage.signing)), {
-        signingScheme: getSigningScheme(verifyAlgorithm)
-      });
-      return key.verify(new Buffer(octetString), signature);
-    },
-    /**
-    * @desc Get the public key in string format
-    * @param  {string} x509Certificate certificate
-    * @return {string} public key
-    */
-    getKeyInfo: function (x509Certificate: string) {
-      this.getKeyInfo = function (key) {
-        return '<X509Data><X509Certificate>' + x509Certificate + '</X509Certificate></X509Data>';
-      };
-      this.getKey = function (keyInfo) {
-        return utility.getPublicKeyPemFromCertificate(x509Certificate).toString();
-      };
-    },
-    /**
-    * @desc Encrypt the assertion section in Response
-    * @param  {Entity} sourceEntity             source entity
-    * @param  {Entity} targetEntity             target entity
-    * @param {string} entireXML                 response in xml string format
-    * @return {function} a callback to receive the finalized xml
-    */
-    encryptAssertion: function (sourceEntity, targetEntity, entireXML: string, callback) {
-      // Implement encryption after signature if it has
-      if (entireXML) {
-        let sourceEntitySetting = sourceEntity.entitySetting;
-        let targetEntitySetting = targetEntity.entitySetting;
-        let sourceEntityMetadata = sourceEntity.entityMeta;
-        let targetEntityMetadata = targetEntity.entityMeta;
-        let assertionNode = getEntireBody(new dom().parseFromString(entireXML), 'Assertion');
-        let assertion = assertionNode !== undefined ? utility.parseString(assertionNode.toString()) : '';
+					if (typeof localName === 'string') {
+						objKey = localName;
+						if (extractEntireBody) {
+							res = getEntireBody(doc, localName);
+						} else {
+							if (attributes.length !== 0) {
+								res = getAttributes(doc, localName, attributes);
+							} else {
+								res = getInnerText(doc, localName);
+							}
+						}
+					} else {
+						objKey = localName.tag;
+						if (field.attributeTag) {
+							res = getAttributeKey(doc, objKey, localName.key, field.attributeTag);
+						} else if (field.valueTag) {
+							res = getInnerTextWithOuterKey(doc, objKey, localName.key, field.valueTag);
+						}
+					}
+					meta[customKey === '' ? objKey.toLowerCase() : customKey] = res;
+				}
+			});
+			return <ExtractorResultInterface>meta;
+		},
+		/**
+		* @desc Helper function to create the key section in metadata (abstraction for signing and encrypt use)
+		* @param  {string} use          type of certificate (e.g. signing, encrypt)
+		* @param  {string} certFile     declares the .cer file (e.g. path/certificate.cer)
+		* @return {object} object used in xml module
+		*/
+		createKeySection: function (use: string, certFile: string) {
+			return {
+				KeyDescriptor: [{
+					_attr: { use }
+				}, {
+					KeyInfo: [{
+						_attr: {
+							'xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#'
+						}
+					}, {
+						X509Data: [{
+							X509Certificate: utility.parseCerFile(certFile)
+						}]
+					}]
+				}]
+			};
+		},
+		/**
+		* @desc Constructs SAML message
+		* @param  {string} octetString               see "Bindings for the OASIS Security Assertion Markup Language (SAML V2.0)" P.17/46
+		* @param  {string} keyFile                   declares the .pem file storing the private key (e.g. path/privkey.pem)
+		* @param  {string} passphrase                passphrase of .pem file [optional]
+		* @param  {string} signingAlgorithm          signing algorithm (SS-1.1)
+		* @return {string} message signature
+		*/
+		constructMessageSignature: function (octetString: string, keyFile: string, passphrase: string, isBase64: boolean, signingAlgorithm: string) {
+			// Default returning base64 encoded signature
+			// Embed with node-rsa module
+			let key = new nrsa(utility.readPrivateKeyFromFile(keyFile, passphrase), {
+				signingScheme: getSigningScheme(signingAlgorithm) // SS-1.1
+			});
+			let signature = key.sign(octetString);
+			// Use private key to sign data
+			return isBase64 !== false ? signature.toString('base64') : signature;
+		},
+		/**
+		* @desc Verifies message signature
+		* @param  {Metadata} metadata                 metadata object of identity provider or service provider
+		* @param  {string} octetString                see "Bindings for the OASIS Security Assertion Markup Language (SAML V2.0)" P.17/46
+		* @param  {string} signature                  context of XML signature
+		* @param  {string} verifyAlgorithm            algorithm used to verify (SS-1.1)
+		* @return {boolean} verification result
+		*
+		* SS1.1 Code refractoring
+		*/
+		verifyMessageSignature: function (metadata, octetString: string, signature: string | Buffer, verifyAlgorithm: string) {
+			let key = new nrsa(utility.getPublicKeyPemFromCertificate(metadata.getX509Certificate(certUsage.signing)), {
+				signingScheme: getSigningScheme(verifyAlgorithm)
+			});
+			return key.verify(new Buffer(octetString), signature);
+		},
+		/**
+		* @desc Get the public key in string format
+		* @param  {string} x509Certificate certificate
+		* @return {string} public key
+		*/
+		getKeyInfo: function (x509Certificate: string) {
+			this.getKeyInfo = function (key) {
+				return '<X509Data><X509Certificate>' + x509Certificate + '</X509Certificate></X509Data>';
+			};
+			this.getKey = function (keyInfo) {
+				return utility.getPublicKeyPemFromCertificate(x509Certificate).toString();
+			};
+		},
+		/**
+		* @desc Encrypt the assertion section in Response
+		* @param  {Entity} sourceEntity             source entity
+		* @param  {Entity} targetEntity             target entity
+		* @param {string} entireXML                 response in xml string format
+		* @return {Promise} a promise to resolve the finalized xml
+		*/
+		encryptAssertion: function (sourceEntity, targetEntity, entireXML: string) {
+			// Implement encryption after signature if it has
+			return new Promise<string>((resolve,reject) => {
+				if (entireXML) {
+					let sourceEntitySetting = sourceEntity.entitySetting;
+					let targetEntitySetting = targetEntity.entitySetting;
+					let sourceEntityMetadata = sourceEntity.entityMeta;
+					let targetEntityMetadata = targetEntity.entityMeta;
+					let assertionNode = getEntireBody(new dom().parseFromString(entireXML), 'Assertion');
+					let assertion = assertionNode !== undefined ? utility.parseString(assertionNode.toString()) : '';
 
-        if (assertion === '') {
-          throw new Error('Undefined assertion or invalid syntax');
-        }
-        // Perform encryption depends on the setting, default is false
-        if (sourceEntitySetting.isAssertionEncrypted) {
-          // callback should be function (res) { ... }
-          xmlenc.encrypt(assertion, {
-            // use xml-encryption module
-            rsa_pub: new Buffer(utility.getPublicKeyPemFromCertificate(targetEntityMetadata.getX509Certificate(certUsage.encrypt)).replace(/\r?\n|\r/g, '')), // public key from certificate
-            pem: new Buffer('-----BEGIN CERTIFICATE-----' + targetEntityMetadata.getX509Certificate(certUsage.encrypt) + '-----END CERTIFICATE-----'),
-            encryptionAlgorithm: sourceEntitySetting.dataEncryptionAlgorithm,
-            keyEncryptionAlgorighm: sourceEntitySetting.keyEncryptionAlgorithm
-          }, (err, res) => {
-            if (err) {
-              throw new Error('Exception in encrpytedAssertion ' + err);
-            }
-            if (!res) {
-              throw new Error('Undefined encrypted assertion');
-            }
-            return callback(utility.base64Encode(entireXML.replace(assertion, '<saml:EncryptedAssertion>' + res + '</saml:EncryptedAssertion>')));
-          });
-        } else {
-          return callback(utility.base64Encode(entireXML)); // No need to do encrpytion
-        }
-      } else {
-        throw new Error('Empty or undefined xml string');
-      }
-    },
-    /**
-    * @desc Decrypt the assertion section in Response
-    * @param  {string} type             only accept SAMLResponse to proceed decryption
-    * @param  {Entity} here             this entity
-    * @param  {Entity} from             from the entity where the message is sent
-    * @param {string} entireXML         response in xml string format
-    * @return {function} a callback to get back the entire xml with decrypted assertion
-    */
-    decryptAssertion: function (type: string, here, from, entireXML: string | Buffer, callback) {
-      // Implement decryption first then check the signature
-      if (entireXML) {
-        // Perform encryption depends on the setting of where the message is sent, default is false
-        if (type === 'SAMLResponse' && from.entitySetting.isAssertionEncrypted) {
-          let hereSetting = here.entitySetting;
-          let parseEntireXML = new dom().parseFromString(String(entireXML));
-          let encryptedDataNode = getEntireBody(parseEntireXML, 'EncryptedData');
-          let encryptedData = encryptedDataNode !== undefined ? utility.parseString(encryptedDataNode.toString()) : '';
-          if (encryptedData === '') {
-            throw new Error('Undefined assertion or invalid syntax');
-          }
-          return xmlenc.decrypt(encryptedData, {
-            key: utility.readPrivateKeyFromFile(hereSetting.encPrivateKeyFile, hereSetting.encPrivateKeyFilePass)
-          }, (err, res) => {
-            if (err) {
-              throw new Error('Exception in decryptAssertion ' + err);
-            }
-            if (!res) {
-              throw new Error('Undefined encrypted assertion');
-            }
-            return callback(String(parseEntireXML).replace('<saml:EncryptedAssertion>', '').replace('</saml:EncryptedAssertion>', '').replace(encryptedData, res));
-          });
-        } else {
-          return callback(entireXML); // No need to do encrpytion
-        }
-      } else {
-        throw new Error('Empty or undefined xml string');
-      }
-    }
-  };
+					if (assertion === '') {
+						return  reject('Undefined assertion or invalid syntax');
+					}
+					// Perform encryption depends on the setting, default is false
+					if (sourceEntitySetting.isAssertionEncrypted) {
+						xmlenc.encrypt(assertion, {
+							// use xml-encryption module
+							rsa_pub: new Buffer(utility.getPublicKeyPemFromCertificate(targetEntityMetadata.getX509Certificate(certUsage.encrypt)).replace(/\r?\n|\r/g, '')), // public key from certificate
+							pem: new Buffer('-----BEGIN CERTIFICATE-----' + targetEntityMetadata.getX509Certificate(certUsage.encrypt) + '-----END CERTIFICATE-----'),
+							encryptionAlgorithm: sourceEntitySetting.dataEncryptionAlgorithm,
+							keyEncryptionAlgorighm: sourceEntitySetting.keyEncryptionAlgorithm
+						}, (err, res) => {
+							if (err) {
+								return  reject('Exception in encrpytedAssertion ' + err);
+							}
+							if (!res) {
+								return  reject('Undefined encrypted assertion');
+							}
+							return resolve(utility.base64Encode(entireXML.replace(assertion, '<saml:EncryptedAssertion>' + res + '</saml:EncryptedAssertion>')));
+						});
+					} else {
+						return resolve(utility.base64Encode(entireXML)); // No need to do encrpytion
+					}
+				} else {
+					return  reject('Empty or undefined xml string');
+				}
+			})
+		},
+		/**
+		* @desc Decrypt the assertion section in Response
+		* @param  {string} type             only accept SAMLResponse to proceed decryption
+		* @param  {Entity} here             this entity
+		* @param  {Entity} from             from the entity where the message is sent
+		* @param {string} entireXML         response in xml string format
+		* @return {function} a promise to get back the entire xml with decrypted assertion
+		*/
+		decryptAssertion: function (type: string, here, from, entireXML: string | Buffer) {
+			return new Promise<string>((resolve,reject) => {
+				// Implement decryption first then check the signature
+				if (entireXML) {
+					// Perform encryption depends on the setting of where the message is sent, default is false
+					if (type === 'SAMLResponse' && from.entitySetting.isAssertionEncrypted) {
+						let hereSetting = here.entitySetting;
+						let parseEntireXML = new dom().parseFromString(String(entireXML));
+						let encryptedDataNode = getEntireBody(parseEntireXML, 'EncryptedData');
+						let encryptedData = encryptedDataNode !== undefined ? utility.parseString(encryptedDataNode.toString()) : '';
+						if (encryptedData === '') {
+							return reject('Undefined assertion or invalid syntax');
+						}
+						return xmlenc.decrypt(encryptedData, {
+							key: utility.readPrivateKeyFromFile(hereSetting.encPrivateKeyFile, hereSetting.encPrivateKeyFilePass)
+						}, (err, res) => {
+							if (err) {
+								return reject('Exception in decryptAssertion ' + err);
+							}
+							if (!res) {
+								return reject('Undefined encrypted assertion');
+							}
+							return resolve(String(parseEntireXML).replace('<saml:EncryptedAssertion>', '').replace('</saml:EncryptedAssertion>', '').replace(encryptedData, res));
+						});
+					} else {
+						return resolve(entireXML); // No need to do encrpytion
+					}
+				} else {
+					return reject('Empty or undefined xml string');
+				}
+			});
+
+		}
+	};
 }
 
 export default libSaml();

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -492,7 +492,7 @@ const libSaml = function () {
           let assertion = assertionNode !== undefined ? utility.parseString(assertionNode.toString()) : '';
 
           if (assertion === '') {
-            return  reject('Undefined assertion or invalid syntax');
+            return  reject(new Error('Undefined assertion or invalid syntax'));
           }
           // Perform encryption depends on the setting, default is false
           if (sourceEntitySetting.isAssertionEncrypted) {
@@ -504,10 +504,10 @@ const libSaml = function () {
               keyEncryptionAlgorighm: sourceEntitySetting.keyEncryptionAlgorithm
             }, (err, res) => {
               if (err) {
-                return  reject('Exception in encrpytedAssertion ' + err);
+                return  reject(new Error('Exception in encrpytedAssertion ' + err));
               }
               if (!res) {
-                return  reject('Undefined encrypted assertion');
+                return  reject(new Error('Undefined encrypted assertion'));
               }
               return resolve(utility.base64Encode(entireXML.replace(assertion, '<saml:EncryptedAssertion>' + res + '</saml:EncryptedAssertion>')));
             });
@@ -515,7 +515,7 @@ const libSaml = function () {
             return resolve(utility.base64Encode(entireXML)); // No need to do encrpytion
           }
         } else {
-          return  reject('Empty or undefined xml string');
+          return  reject(new Error('Empty or undefined xml string'));
         }
       })
     },
@@ -538,16 +538,16 @@ const libSaml = function () {
             let encryptedDataNode = getEntireBody(parseEntireXML, 'EncryptedData');
             let encryptedData = encryptedDataNode !== undefined ? utility.parseString(encryptedDataNode.toString()) : '';
             if (encryptedData === '') {
-              return reject('Undefined assertion or invalid syntax');
+              return reject(new Error('Undefined assertion or invalid syntax'));
             }
             return xmlenc.decrypt(encryptedData, {
               key: utility.readPrivateKeyFromFile(hereSetting.encPrivateKeyFile, hereSetting.encPrivateKeyFilePass)
             }, (err, res) => {
               if (err) {
-                return reject('Exception in decryptAssertion ' + err);
+                return reject(new Error('Exception in decryptAssertion ' + err));
               }
               if (!res) {
-                return reject('Undefined encrypted assertion');
+                return reject(new Error('Undefined encrypted assertion'));
               }
               return resolve(String(parseEntireXML).replace('<saml:EncryptedAssertion>', '').replace('</saml:EncryptedAssertion>', '').replace(encryptedData, res));
             });
@@ -555,7 +555,7 @@ const libSaml = function () {
             return resolve(entireXML); // No need to do encrpytion
           }
         } else {
-          return reject('Empty or undefined xml string');
+          return reject(new Error('Empty or undefined xml string'));
         }
       });
 


### PR DESCRIPTION
This PR replaces the callbacks with promises where it makes sense + updates the examples accordingly
Internally it makes use of typescript's async/await features at some places.

The remaining callbacks are for the custom templates, these can remain callbacks and don't need the `(error,result)` signature, since they're not asynchronous callbacks.

Here and there I just added an `any` return type to make compilation work. It might be better to define result interfaces, but that could be done in a future PR.