### PR TITLE
Pass in raw strings/buffers for metadata and certificates

### DIFF
--- a/examples/idp/routes/sso.js
+++ b/examples/idp/routes/sso.js
@@ -16,27 +16,27 @@ var epn = {
 /// Declare that entity, and load all settings when server is started
 /// Restart server is needed when new metadata is imported
 var idp1 = require('../../../build/index').IdentityProvider({
-  privateKeyFile: '../key/idp/privkey.pem',
+  privateKey: fs.readFileSync('../key/idp/privkey.pem'),
   isAssertionEncrypted: true,
-  encPrivateKeyFile: '../key/idp/encryptKey.pem',
-  encPrivateKeyFilePass: 'g7hGcRmp8PxT5QeP2q9Ehf1bWe9zTALN',
-  privateKeyFilePass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
-  metadata: '../metadata/metadata_idp1.xml'
+  encPrivateKey: fs.readFileSync('../key/idp/encryptKey.pem'),
+  encPrivateKeyPass: 'g7hGcRmp8PxT5QeP2q9Ehf1bWe9zTALN',
+  privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+  metadata: fs.readFileSync('../metadata/metadata_idp1.xml')
 });
 
 
 var idp2 = require('../../../build/index').IdentityProvider({
-  privateKeyFile: '../key/idp/privkey.pem',
+  privateKey: fs.readFileSync('../key/idp/privkey.pem'),
   isAssertionEncrypted: true,
-  encPrivateKeyFile: '../key/idp/encryptKey.pem',
-  encPrivateKeyFilePass: 'g7hGcRmp8PxT5QeP2q9Ehf1bWe9zTALN',
-  privateKeyFilePass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
-  metadata: '../metadata/metadata_idp2.xml'
+  encPrivateKey: fs.readFileSync('../key/idp/encryptKey.pem'),
+  encPrivateKeyPass: 'g7hGcRmp8PxT5QeP2q9Ehf1bWe9zTALN',
+  privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+  metadata: fs.readFileSync('../metadata/metadata_idp2.xml')
 });
 
 /// Declare the sp
-var sp1 = require('../../../build/index').ServiceProvider({ metadata: '../metadata/metadata_sp1.xml' });
-var sp2 = require('../../../build/index').ServiceProvider({ metadata: '../metadata/metadata_sp2.xml' });
+var sp1 = require('../../../build/index').ServiceProvider({ metadata: fs.readFileSync('../metadata/metadata_sp1.xml') });
+var sp2 = require('../../../build/index').ServiceProvider({ metadata: fs.readFileSync('../metadata/metadata_sp2.xml') });
 
 /// metadata is publicly released, can access at /sso/metadata
 router.get('/metadata/:id', function (req, res, next) {
@@ -113,6 +113,13 @@ router.get('/SingleSignOnService/:id', function (req, res) {
   })
   .then(response => {
     res.render('actions', response);
+  })
+  .catch(err => {
+    console.log(err);
+
+    res.render('error', {
+      message: err.message
+    });
   });
 });
 
@@ -127,6 +134,8 @@ router.post('/SingleSignOnService/:id', function (req, res) {
   }).then(response => {
     res.render('actions', response);
   }).catch(err => {
+    console.log(err);
+
     res.render('error', {
       message: err.message
     });
@@ -148,6 +157,8 @@ router.get('/SingleLogoutService/:id', function (req, res) {
         res.redirect('/login');
       }
     }).catch(err => {
+      console.log(err);
+
       res.render('error', {
         message: err.message
       });
@@ -170,6 +181,8 @@ router.post('/SingleLogoutService/:id', function (req, res) {
     }
   })
   .catch(err => {
+    console.log(err);
+
     res.render('error', {
       message: err.message
     });
@@ -218,6 +231,8 @@ router.get('/select/:id', function (req, res) {
     res.render('actions', response);
   })
   .catch(err => {
+    console.log(err);
+
     res.render('error', {
       message: err.message
     });

--- a/examples/sp1/routes/sso.js
+++ b/examples/sp1/routes/sso.js
@@ -32,29 +32,30 @@ if (!Object.assign) {
   });
 }
 
+var fs = require('fs');
 var express = require('express');
 var router = express.Router();
 var utility = require('../../../build/index').Utility;
 var ServiceProvider = require('../../../build/index').ServiceProvider;
 var IdentityProvider = require('../../../build/index').IdentityProvider;
 
-var SPMetadata = '../metadata/metadata_sp1.xml';
-var SPMetadataForOnelogin = '../metadata/metadata_sp1_onelogin.xml';
+var SPMetadata = fs.readFileSync('../metadata/metadata_sp1.xml');
+var SPMetadataForOnelogin = fs.readFileSync('../metadata/metadata_sp1_onelogin.xml');
 
 var config = {
-  privateKeyFile: '../key/sp/privkey.pem',
-  privateKeyFilePass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
-  encPrivateKeyFile: '../key/sp/encryptKey.pem',
-  encPrivateKeyFilePass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+  privateKey: fs.readFileSync('../key/sp/privkey.pem'),
+  privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+  encPrivateKey: fs.readFileSync('../key/sp/encryptKey.pem'),
+  encPrivateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
   requestSignatureAlgorithm: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512',
   metadata: SPMetadata
 };
 
 var sp = ServiceProvider(config);
-var idp = IdentityProvider({ isAssertionEncrypted: true, metadata: '../metadata/metadata_idp1.xml' });
+var idp = IdentityProvider({ isAssertionEncrypted: true, metadata: fs.readFileSync('../metadata/metadata_idp1.xml') });
 
 // Simple integration to OneLogin
-var oneLoginIdP = IdentityProvider({ metadata: '../metadata/onelogin_metadata_486670.xml' });
+var oneLoginIdP = IdentityProvider({ metadata: fs.readFileSync('../metadata/onelogin_metadata_486670.xml') });
 var olsp = ServiceProvider({ metadata: SPMetadataForOnelogin });
 
 ///

--- a/examples/sp2/routes/sso.js
+++ b/examples/sp2/routes/sso.js
@@ -1,18 +1,19 @@
 var express = require('express');
 var router = express.Router();
+var fs = require('fs');
 
 var sp = require('../../../build/index').ServiceProvider({
-  privateKeyFile: '../key/sp/privkey.pem',
-  privateKeyFilePass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
-  encPrivateKeyFile: '../key/sp/encryptKey.pem',
-  encPrivateKeyFilePass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+  privateKey: fs.readFileSync('../key/sp/privkey.pem'),
+  privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+  encPrivateKey: fs.readFileSync('../key/sp/encryptKey.pem'),
+  encPrivateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
   requestSignatureAlgorithm: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
   metadata: '../metadata/metadata_sp2.xml'
 });
 
 var idp = require('../../../build/index').IdentityProvider({
   isAssertionEncrypted: true,
-  metadata: '../metadata/metadata_idp2.xml'
+  metadata: fs.readFileSync('../metadata/metadata_idp2.xml')
 });
 
 router.get('/metadata', function (req, res, next) {

--- a/src/binding-post.ts
+++ b/src/binding-post.ts
@@ -43,7 +43,7 @@ function base64LoginRequest(referenceTagXPath: string, entity: any, rcallback: (
       });
     }
     if (metadata.idp.isWantAuthnRequestsSigned()) {
-      return libsaml.constructSAMLSignature(rawSamlRequest, referenceTagXPath, metadata.sp.getX509Certificate('signing'), spSetting.privateKeyFile, spSetting.privateKeyFilePass, spSetting.requestSignatureAlgorithm); // SS1.1 add signature algorithm
+      return libsaml.constructSAMLSignature(rawSamlRequest, referenceTagXPath, metadata.sp.getX509Certificate('signing'), spSetting.privateKey, spSetting.privateKeyPass, spSetting.requestSignatureAlgorithm); // SS1.1 add signature algorithm
       // No need to embeded XML signature
     }
     // No need to embeded XML signature
@@ -105,7 +105,7 @@ async function base64LoginResponse(requestInfo: any, referenceTagXPath: string, 
       }
       rawSamlResponse = libsaml.replaceTagsByValue(libsaml.defaultLoginResponseTemplate, tvalue);
     }
-    resXml = metadata.sp.isWantAssertionsSigned() ? libsaml.constructSAMLSignature(rawSamlResponse, referenceTagXPath, metadata.idp.getX509Certificate('signing'), idpSetting.privateKeyFile, idpSetting.privateKeyFilePass, idpSetting.requestSignatureAlgorithm, false) : rawSamlResponse; // SS1.1 add signature algorithm
+    resXml = metadata.sp.isWantAssertionsSigned() ? libsaml.constructSAMLSignature(rawSamlResponse, referenceTagXPath, metadata.idp.getX509Certificate('signing'), idpSetting.privateKey, idpSetting.privateKeyPass, idpSetting.requestSignatureAlgorithm, false) : rawSamlResponse; // SS1.1 add signature algorithm
     // SS-1.1
     if( idpSetting.isAssertionEncrypted ) {
       return await libsaml.encryptAssertion(entity.idp, entity.sp, resXml)
@@ -148,7 +148,7 @@ function base64LogoutRequest(user, referenceTagXPath, entity, rcallback?: (templ
     }
     if (entity.target.entitySetting.wantLogoutRequestSigned) {
       // Need to embeded XML signature
-      return libsaml.constructSAMLSignature(rawSamlRequest, referenceTagXPath, metadata.init.getX509Certificate('signing'), initSetting.privateKeyFile, initSetting.privateKeyFilePass, initSetting.requestSignatureAlgorithm); // SS1.1 add signature algorithm
+      return libsaml.constructSAMLSignature(rawSamlRequest, referenceTagXPath, metadata.init.getX509Certificate('signing'), initSetting.privateKey, initSetting.privateKeyPass, initSetting.requestSignatureAlgorithm); // SS1.1 add signature algorithm
     } else {
       // No need to embeded XML signature
       return utility.base64Encode(rawSamlRequest);
@@ -189,7 +189,7 @@ function base64LogoutResponse(requestInfo: any, referenceTagXPath: string, entit
       rawSamlResponse = libsaml.replaceTagsByValue(libsaml.defaultLogoutResponseTemplate, tvalue);
       if (entity.target.entitySetting.wantLogoutResponseSigned) {
         // Need to embeded XML signature
-        return libsaml.constructSAMLSignature(rawSamlResponse, referenceTagXPath, metadata.init.getX509Certificate('signing'), initSetting.privateKeyFile, initSetting.privateKeyFilePass, initSetting.requestSignatureAlgorithm); // SS1.1 add signature algorithm
+        return libsaml.constructSAMLSignature(rawSamlResponse, referenceTagXPath, metadata.init.getX509Certificate('signing'), initSetting.privateKey, initSetting.privateKeyPass, initSetting.requestSignatureAlgorithm); // SS1.1 add signature algorithm
       }
       // No need to embeded XML signature
       return utility.base64Encode(rawSamlResponse);

--- a/src/binding-redirect.ts
+++ b/src/binding-redirect.ts
@@ -49,7 +49,7 @@ function buildRedirectURL(type: string, isSigned: boolean, rawSamlRequest: strin
     let sigAlg = pvPair(urlParams.sigAlg, encodeURIComponent(entitySetting.requestSignatureAlgorithm));
     let octetString = samlRequest + sigAlg + relayState;
     // include signature algorithm (either SHA1 or SHA256) (SS1.1)
-    return pvPair(queryParam, octetString, true) + pvPair(urlParams.signature, encodeURIComponent(libsaml.constructMessageSignature(type + '=' + octetString, entitySetting.privateKeyFile, entitySetting.privateKeyFilePass, null, entitySetting.requestSignatureAlgorithm)));
+    return pvPair(queryParam, octetString, true) + pvPair(urlParams.signature, encodeURIComponent(libsaml.constructMessageSignature(type + '=' + octetString, entitySetting.privateKey, entitySetting.privateKeyPass, null, entitySetting.requestSignatureAlgorithm)));
   }
   return pvPair(queryParam, samlRequest + relayState, true);
 }

--- a/src/entity-idp.ts
+++ b/src/entity-idp.ts
@@ -33,10 +33,10 @@ export class IdentityProvider extends Entity {
   //
   // if no metadata is provided, idpSetting includes
   // {string}       entityID
-  // {string}       privateKeyFile
-  // {string}       privateKeyFilePass
-  // {string}       signingCertFile
-  // {string}       encryptCertFile (todo)
+  // {string}       privateKey
+  // {string}       privateKeyPass
+  // {string}       signingCert
+  // {string}       encryptCert (todo)
   // {[string]}     nameIDFormat
   // {[object]}     singleSignOnService
   // {[object]}     singleLogoutService
@@ -47,7 +47,7 @@ export class IdentityProvider extends Entity {
   /**
   * @desc  Identity prvider can be configured using either metadata importing or idpSetting
   * @param  {object} idpSetting
-  * @param  {string} metaFile
+  * @param  {string} meta
   */
   constructor(idpSetting) {
     const entitySetting = Object.assign({ wantAuthnRequestsSigned: false }, idpSetting);

--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -30,7 +30,7 @@ export class ServiceProvider extends Entity {
   /**
   * @desc  Inherited from Entity
   * @param {object} spSetting    setting of service provider
-  * @param {string} meta		     metadata path
+  * @param {string} meta		     metadata
   */
   constructor(spSetting) {
     const entitySetting = Object.assign({

--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -24,13 +24,13 @@ export default function (props) {
 /**
 * @desc Service provider can be configured using either metadata importing or spSetting
 * @param  {object} spSetting
-* @param  {string} metaFile
+* @param  {string} meta
 */
 export class ServiceProvider extends Entity {
   /**
   * @desc  Inherited from Entity
   * @param {object} spSetting    setting of service provider
-  * @param {string} metaFile     metadata file path
+  * @param {string} meta		     metadata path
   */
   constructor(spSetting) {
     const entitySetting = Object.assign({

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -43,7 +43,7 @@ export default class Entity {
   * @desc  Constructor
   * @param {object} entitySetting
   * @param {object} entityMetaClass determine whether the entity is IdentityProvider or ServiceProvider
-  * @param {string} entityMeta is the entity metafile path, deprecated after 2.0
+  * @param {string} entityMeta is the entity metadata, deprecated after 2.0
   */
   constructor(entitySetting, entityType) {
     this.entitySetting = Object.assign({}, defaultEntitySetting, entitySetting);

--- a/src/metadata-idp.ts
+++ b/src/metadata-idp.ts
@@ -111,7 +111,7 @@ export class IdpMetadata extends Metadata {
     }, {
       localName: { tag: 'SingleSignOnService', key: 'Binding' },
       attributeTag: 'Location'
-    }], !byMetadata);
+    }]);
 
   }
   /**

--- a/src/metadata-idp.ts
+++ b/src/metadata-idp.ts
@@ -24,7 +24,7 @@ export class IdpMetadata extends Metadata {
 
   constructor(meta) {
 
-    const byMetadata = typeof meta === 'string';
+    const byMetadata = (typeof meta === 'string' || meta instanceof Buffer);
 
     if (!byMetadata) {
       let entityID = meta.entityID;

--- a/src/metadata-idp.ts
+++ b/src/metadata-idp.ts
@@ -29,8 +29,8 @@ export class IdpMetadata extends Metadata {
     if (!byMetadata) {
       let entityID = meta.entityID;
       let wantAuthnRequestsSigned = meta.wantAuthnRequestsSigned === true;
-      let signingCertFile = meta.signingCertFile;
-      let encryptCertFile = meta.encryptCertFile;
+      let signingCert = meta.signingCert;
+      let encryptCert = meta.encryptCert;
       let nameIDFormat = meta.nameIDFormat || [];
       let singleSignOnService = meta.singleSignOnService || [];
       let singleLogoutService = meta.singleLogoutService || [];
@@ -41,15 +41,15 @@ export class IdpMetadata extends Metadata {
         }
       }];
 
-      if (signingCertFile) {
-        IDPSSODescriptor.push(libsaml.createKeySection('signing', signingCertFile));
+      if (signingCert) {
+        IDPSSODescriptor.push(libsaml.createKeySection('signing', signingCert));
       } else {
         //logging
         //console.warn('Construct identity provider - missing signing certificate');
       }
 
-      if (encryptCertFile) {
-        IDPSSODescriptor.push(libsaml.createKeySection('encrypt', encryptCertFile));
+      if (encryptCert) {
+        IDPSSODescriptor.push(libsaml.createKeySection('encrypt', encryptCert));
       } else {
         //logging
         //console.warn('Construct identity provider - missing encrypt certificate');

--- a/src/metadata-sp.ts
+++ b/src/metadata-sp.ts
@@ -112,7 +112,7 @@ export class SpMetadata extends Metadata {
     }
     /**
     * @desc  Initialize with creating a new metadata object
-    * @param {string/objects} meta     declares path of the metadata
+    * @param {string/objects} meta     metadata XML
     * @param {array of Objects}        high-level XML element selector
     */
 

--- a/src/metadata-sp.ts
+++ b/src/metadata-sp.ts
@@ -31,7 +31,7 @@ export class SpMetadata extends Metadata {
   */
   constructor(meta) {
 
-    let byMetadata = typeof meta === 'string';
+    let byMetadata = (typeof meta === 'string' || meta instanceof Buffer);
 
     if (!byMetadata) {
       let entityID = meta.entityID;

--- a/src/metadata-sp.ts
+++ b/src/metadata-sp.ts
@@ -26,7 +26,7 @@ export default function (meta) {
 export class SpMetadata extends Metadata {
 
   /**
-  * @param  {object/string} meta (either file path in string format or configuation in object)
+  * @param  {object/string} meta (either xml string or configuation in object)
   * @return {object} prototypes including public functions
   */
   constructor(meta) {
@@ -37,8 +37,8 @@ export class SpMetadata extends Metadata {
       let entityID = meta.entityID;
       let authnRequestsSigned = meta.authnRequestsSigned === true;
       let wantAssertionsSigned = meta.wantAssertionsSigned === true;
-      let signingCertFile = meta.signingCertFile;
-      let encryptCertFile = meta.encryptCertFile;
+      let signingCert = meta.signingCert;
+      let encryptCert = meta.encryptCert;
       let nameIDFormat = meta.nameIDFormat || [];
       let singleLogoutService = meta.singleLogoutService || [];
       let assertionConsumerService = meta.assertionConsumerService || [];
@@ -51,14 +51,14 @@ export class SpMetadata extends Metadata {
         }
       }];
 
-      if (signingCertFile) {
-        SPSSODescriptor.push(libsaml.createKeySection('signing', signingCertFile));
+      if (signingCert) {
+        SPSSODescriptor.push(libsaml.createKeySection('signing', signingCert));
       } else {
         //console.warn('Construct service provider - missing signing certificate');
       }
 
-      if (encryptCertFile) {
-        SPSSODescriptor.push(libsaml.createKeySection('encrypt', encryptCertFile));
+      if (encryptCert) {
+        SPSSODescriptor.push(libsaml.createKeySection('encrypt', encryptCert));
       } else {
         //console.warn('Construct service provider - missing encrypt certificate');
       }

--- a/src/metadata-sp.ts
+++ b/src/metadata-sp.ts
@@ -122,7 +122,7 @@ export class SpMetadata extends Metadata {
     }, {
       localName: 'AssertionConsumerService',
       attributes: ['Binding', 'Location', 'isDefault', 'index']
-    }], !byMetadata);
+    }]);
   }
 
   /**

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -26,11 +26,11 @@ export default class Metadata implements MetadataInterface {
   xmlString: string;
   meta: any;
   /**
-  * @param  {string} xmlString is an xmlString
+  * @param  {string | Buffer} metadata xml
   * @param  {object} extraParse for custom metadata extractor
   */
-  constructor (xmlString: string, extraParse) {
-    this.xmlString = xmlString;
+  constructor (xml: string | Buffer, extraParse) {
+    this.xmlString = xml.toString();
     this.meta = libsaml.extractor(this.xmlString, Array.prototype.concat([{
       localName: 'EntityDescriptor',
       attributes: ['entityID']

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -27,12 +27,11 @@ export default class Metadata implements MetadataInterface {
   xmlString: string;
   meta: any;
   /**
-  * @param  {string} meta is either xmlString or file name
+  * @param  {string} xmlString is an xmlString
   * @param  {object} extraParse for custom metadata extractor
-  * @param  {Boolean} isXml declares whether meta is xmlString or filePath
   */
-  constructor (meta, extraParse, isXml?: boolean) {
-    this.xmlString = isXml === true ? String(meta) :　String(fs.readFileSync(meta));
+  constructor (xmlString, extraParse) {
+    this.xmlString = xmlString;
     this.meta = libsaml.extractor(this.xmlString, Array.prototype.concat([{
       localName: 'EntityDescriptor',
       attributes: ['entityID']

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -12,7 +12,6 @@ const certUse = wording.certUse;
 
 export interface MetadataInterface {
   xmlString: string;
-  meta: any;
   getMetadata: () => string;
   exportMetadata: (exportFile: string) => void;
   getEntityID: () => string;
@@ -30,7 +29,7 @@ export default class Metadata implements MetadataInterface {
   * @param  {string} xmlString is an xmlString
   * @param  {object} extraParse for custom metadata extractor
   */
-  constructor (xmlString, extraParse) {
+  constructor (xmlString: string, extraParse) {
     this.xmlString = xmlString;
     this.meta = libsaml.extractor(this.xmlString, Array.prototype.concat([{
       localName: 'EntityDescriptor',

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -47,29 +47,29 @@ function inflateString(compressedString: string): string {
   .join('');
 }
 /**
-* @desc Abstract the parseCerFile and normalizePemString
-* @param {buffer} File stream
-* @param {string} String for header and tail of file
+* @desc Abstract the normalizeCerString and normalizePemString
+* @param {buffer} File stream or string
+* @param {string} String for header and tail
 * @return {string} A formatted certificate string
 */
-function normalizeCerString(bin, format: string) {
+function _normalizeCerString(bin: string | Buffer, format: string) {
   return bin.toString().replace(/\n/g, '').replace(/\r/g, '').replace(`-----BEGIN ${format}-----`, '').replace(`-----END ${format}-----`, '');
 }
 /**
 * @desc Parse the .cer to string format without line break, header and footer
-* @param  {string} certFile     declares the .cer file (e.g. path/certificate.cer)
+* @param  {string} certString     declares the certificate contents
 * @return {string} certificiate in string format
 */
-function parseCerFile(certFile: string){
-  return normalizeCerString(fs.readFileSync(certFile), 'CERTIFICATE');
+function normalizeCerString(certString: string | Buffer){
+  return _normalizeCerString(certString, 'CERTIFICATE');
 }
 /**
 * @desc Normalize the string in .pem format without line break, header and footer
 * @param  {string} pemString
 * @return {string} private key in string format
 */
-function normalizePemString(pemString: string){
-  return normalizeCerString(pemString.toString(), 'RSA PRIVATE KEY');
+function normalizePemString(pemString: string | Buffer){
+  return _normalizeCerString(pemString.toString(), 'RSA PRIVATE KEY');
 }
 /**
 * @desc Return the complete URL
@@ -108,14 +108,14 @@ function getPublicKeyPemFromCertificate(x509Certificate: string){
   return pki.publicKeyToPem(cert.publicKey);
 }
 /**
-* @desc Read private key from .pem file
-* @param {string} path of the .pem file
-* @param {string} protected passphrase of the keyFile
+* @desc Read private key from pem-formatted string
+* @param {string | Buffer} keyString pem-formattted string
+* @param {string} protected passphrase of the key
 * @return {string} string in pem format
-* If passphrase is used to protect the .pem file (recommend)
+* If passphrase is used to protect the .pem content (recommend)
 */
-function readPrivateKeyFromFile(keyFile: string, passphrase: string, isOutputString?: boolean){
-  return typeof passphrase === 'string' ? this.convertToString(pki.privateKeyToPem(pki.decryptRsaPrivateKey(String(fs.readFileSync(keyFile)), passphrase)), isOutputString) : fs.readFileSync(keyFile);
+function readPrivateKey(keyString: string | Buffer, passphrase: string, isOutputString?: boolean){
+  return typeof passphrase === 'string' ? this.convertToString(pki.privateKeyToPem(pki.decryptRsaPrivateKey(String(keyString), passphrase)), isOutputString) : keyString;
 }
 /**
 * @desc Inline syntax sugar
@@ -129,13 +129,13 @@ const utility = {
   base64Decode,
   deflateString,
   inflateString,
-  parseCerFile,
+  normalizeCerString,
   normalizePemString,
   getFullURL,
   parseString,
   applyDefault,
   getPublicKeyPemFromCertificate,
-  readPrivateKeyFromFile,
+  readPrivateKey,
   convertToString
 };
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -29,20 +29,20 @@ const _spPrivKeyPass = 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px';
 
 // Define an identity provider
 const idp = identityProvider({
-  privateKeyFile: './test/key/idp/privkey.pem',
-  privateKeyFilePass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
+  privateKey: fs.readFileSync('./test/key/idp/privkey.pem'),
+  privateKeyPass: 'q9ALNhGT5EhfcRmp8Pg7e9zTQeP2x1bW',
   isAssertionEncrypted: true,
-  encPrivateKeyFile: './test/key/idp/encryptKey.pem',
-  encPrivateKeyFilePass: 'g7hGcRmp8PxT5QeP2q9Ehf1bWe9zTALN',
+  encPrivateKey: fs.readFileSync('./test/key/idp/encryptKey.pem'),
+  encPrivateKeyPass: 'g7hGcRmp8PxT5QeP2q9Ehf1bWe9zTALN',
   metadata: './test/metadata/IDPMetadata.xml'
 });
 
 const sp = serviceProvider({
-  privateKeyFile: './test/key/sp/privkey.pem',
-  privateKeyFilePass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
+  privateKey: fs.readFileSync('./test/key/sp/privkey.pem'),
+  privateKeyPass: 'VHOSp5RUiBcrsjrcAuXFwU1NKCkGA8px',
   isAssertionEncrypted: true, // for logout purpose
-  encPrivateKeyFile: './test/key/sp/encryptKey.pem',
-  encPrivateKeyFilePass: 'BXFNKpxrsjrCkGA8cAu5wUVHOSpci1RU',
+  encPrivateKey: fs.readFileSync('./test/key/sp/encryptKey.pem'),
+  encPrivateKeyPass: 'BXFNKpxrsjrCkGA8cAu5wUVHOSpci1RU',
   metadata: './test/metadata/SPMetadata.xml'
 });
 
@@ -73,7 +73,7 @@ test('base64 decoded + inflate', t => {
   t.is(utility.inflateString('80jNyclXCM8vykkBAA=='), 'Hello World');
 });
 test('parse cer format resulting clean certificate', t => {
-  t.is(utility.parseCerFile('./test/key/sp/cert.cer'), spCertKnownGood);
+  t.is(utility.normalizeCerString(fs.readFileSync('./test/key/sp/cert.cer')), spCertKnownGood);
 });
 test('normalize pem key returns clean string', t => {
 	const ekey = fs.readFileSync('./test/key/sp/encryptKey.pem').toString();


### PR DESCRIPTION
This allows the user to pass in buffers and strings instead of file paths.

Advantages are more flexibility, e.g.:
- User can decide whether to read files synchronous or asynchronous
- User can pass in XML and Certificates/Keys that are not stored in files. E.g. coming from a database, fetched from a url, ...

Disadvantage: to keep the library simple, I removed the functionality that read the files, but reading a file is so easy in node, that this is a small cost. It could be re-added, but I didn't really see the point, it only adds complexity to the library with little benefit for the user.