### PR TITLE
Proposal of naming changes

### DIFF
--- a/src/binding-post.ts
+++ b/src/binding-post.ts
@@ -18,6 +18,8 @@ const binding = wording.binding;
 * @param  {object} entity                      object includes both idp and sp
 * @param  {function} rcallback     used when developers have their own login response template
 */
+
+//It's unclear to me what the 'r' in 'rcallback' stands for. requestCallback? if so, that migth be a better name
 function base64LoginRequest(referenceTagXPath: string, entity: any, rcallback: (template: string) => string) {
   let metadata = { idp: entity.idp.entityMeta, sp: entity.sp.entityMeta };
   let spSetting = entity.sp.entitySetting;
@@ -59,6 +61,8 @@ function base64LoginRequest(referenceTagXPath: string, entity: any, rcallback: (
 * @param  {object} user                        current logged user (e.g. req.user)
 * @param  {function} rcallback     used when developers have their own login response template
 */
+
+//It's unclear to me what the 'r' in 'rcallback' stands for. responseCallback? if so, that migth be a better name
 async function base64LoginResponse(requestInfo: any, referenceTagXPath: string, entity: any, user: any, rcallback: (template: string) => string) {
   let metadata = {
     idp: entity.idp.entityMeta,
@@ -124,6 +128,7 @@ async function base64LoginResponse(requestInfo: any, referenceTagXPath: string, 
 * @param  {function} rcallback      used when developers have their own login response template
 * @return {string} base64 encoded request
 */
+//It's unclear to me what the 'r' in 'rcallback' stands for. requestCallback? if so, that migth be a better name
 function base64LogoutRequest(user, referenceTagXPath, entity, rcallback?: (template: string) => string): string {
   let metadata = {
     init: entity.init.entityMeta,
@@ -164,6 +169,7 @@ function base64LogoutRequest(user, referenceTagXPath, entity, rcallback?: (templ
 * @param  {object} entity                      object includes both idp and sp
 * @param  {function} rcallback     used when developers have their own login response template
 */
+//It's unclear to me what the 'r' in 'rcallback' stands for. responseCallback? if so, that migth be a better name
 function base64LogoutResponse(requestInfo: any, referenceTagXPath: string, entity: any, rcallback: (template: string) => string) {
   let metadata = {
     init: entity.init.entityMeta,

--- a/src/entity-idp.ts
+++ b/src/entity-idp.ts
@@ -14,6 +14,7 @@ import * as _ from 'lodash';
 const bindDict = wording.binding;
 const xmlTag = tags.xmlTag;
 const metaWord = wording.metadata;
+//Why not an import?
 const xml = require('xml');
 
 /*
@@ -63,7 +64,9 @@ export class IdentityProvider extends Entity {
   * @param  {object}   user                      current logged user (e.g. req.user)
   * @param  {function} rcallback                 used when developers have their own login response template
   */
-  public async sendLoginResponse(sp, requestInfo, binding, user, rcallback) {
+   //It's not actually sending anything, so I renamed to 'create'
+   //What does the 'r' in 'rcallback' stand for? Maybe rename to be more clear?
+  public async createLoginResponse(sp, requestInfo, binding, user, rcallback) {
     const protocol = namespace.binding[binding] || namespace.binding.redirect;
     if (protocol == namespace.binding.post) {
       const res = await postBinding.base64LoginResponse(requestInfo, libsaml.createXPath('Assertion'), {

--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -46,7 +46,8 @@ export class ServiceProvider extends Entity {
   * @param  {string}   binding                   protocol binding
   * @param  {function} rcallback     used when developers have their own login response template
   */
-  public sendLoginRequest(idp, binding, rcallback): any {
+   //It's not actually sending anything, so I renamed to 'create'
+  public createLoginRequest(idp, binding, rcallback): any {
     const protocol = namespace.binding[binding] || namespace.binding.redirect;
     if (protocol == namespace.binding.redirect) {
       return redirectBinding.loginRequestRedirectURL({

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -239,7 +239,8 @@ export default class Entity {
   * @param  {string} relayState      the URL to which to redirect the user when logout is complete
   * @param  {function} rcallback     used when developers have their own login response template
   */
-  sendLogoutRequest(targetEntity, binding, user, relayState, rcallback): any {
+  //It's not actually sending anything, so I renamed to 'create'
+  createLogoutRequest(targetEntity, binding, user, relayState, rcallback): any {
     if (binding === wording.binding.redirect) {
       return redirectBinding.logoutRequestRedirectURL(user, {
         init: this,
@@ -267,7 +268,8 @@ export default class Entity {
   * @param  {string} binding                     protocol binding
   * @param  {function} rcallback                 used when developers have their own login response template
   */
-  sendLogoutResponse(targetEntity, requestInfo, binding, relayState, rcallback): any {
+  //It's not actually sending anything, so I renamed to 'create'
+  createLogoutResponse(targetEntity, requestInfo, binding, relayState, rcallback): any {
     binding = namespace.binding[binding] || namespace.binding.redirect;
     if (binding === namespace.binding.redirect) {
       return redirectBinding.logoutResponseRedirectURL(requestInfo, {

--- a/src/libsaml.ts
+++ b/src/libsaml.ts
@@ -14,6 +14,7 @@ import utility from './utility';
 import { tags, algorithms, wording } from './urn';
 import xpath, { select } from 'xpath';
 
+//Why are these not imports?
 const nrsa = require('node-rsa');
 const xml = require('xml');
 const xmlenc = require('xml-encryption');
@@ -38,9 +39,9 @@ export interface LibSamlInterface {
   getQueryParamByType: (type: string) => string;
   createXPath: (local, isExtractAll?: boolean) => string;
   replaceTagsByValue: (rawXML: string, tagValues: { any }) => string;
-  constructSAMLSignature: (xmlString: string, referenceXPath: string, x509: string, key: string | Buffer, passphrase: string, signatureAlgorithm: string, isBase64Output?: boolean) => string;
+  constructSAMLSignature: (xmlDoc: string, referenceXPath: string, x509: string, key: string | Buffer, passphrase: string, signatureAlgorithm: string, isBase64Output?: boolean) => string;
   verifySignature: (xml: string, signature, opts) => boolean;
-  extractor: (xmlString: string, fields) => ExtractorResultInterface;
+  extractor: (xmlDoc: string, fields) => ExtractorResultInterface; //Since we have typescript intellisense anyway, it seems like bad practice to include the type in the variable name...
   createKeySection: (use: string, cert: string | Buffer) => {};
   constructMessageSignature: (octetString: string, key: string | Buffer, passphrase?: string, isBase64?: boolean, signingAlgorithm?: string) => string;
   verifyMessageSignature: (metadata, octetString: string, signature: string | Buffer, verifyAlgorithm?: string) => boolean;
@@ -322,7 +323,7 @@ const libSaml = function () {
     * @param  {string} signatureAlgorithm   signature algorithm (SS-1.1)
     * @return {string} base64 encoded string
     */
-    constructSAMLSignature: function (xmlString: string, referenceXPath: string, x509: string, key: string | Buffer, passphrase: string, signatureAlgorithm: string, isBase64Output?: boolean) {
+    constructSAMLSignature: function (xmlDoc: string, referenceXPath: string, x509: string, key: string | Buffer, passphrase: string, signatureAlgorithm: string, isBase64Output?: boolean) {
       let sig = new SignedXml();
       // Add assertion sections as reference
       if (referenceXPath && referenceXPath !== '') {
@@ -368,7 +369,7 @@ const libSaml = function () {
     * @param  {string} xmlString
     * @param  {object} fields
     */
-    extractor: function (xmlString: string, fields) {
+    extractor: function (xmlDoc: string, fields) {
       let doc = new dom().parseFromString(xmlString);
       let meta = {};
       fields.forEach(field => {

--- a/src/metadata-sp.ts
+++ b/src/metadata-sp.ts
@@ -7,6 +7,7 @@ import Metadata, { MetadataInterface } from './metadata';
 import { namespace } from './urn';
 import libsaml from './libsaml';
 
+//Why is this require and not import?
 const xml = require('xml');
 
 export interface SpMetadataInterface extends MetadataInterface {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -52,7 +52,9 @@ function inflateString(compressedString: string): string {
 * @param {string} String for header and tail
 * @return {string} A formatted certificate string
 */
-function _normalizeCerString(bin: string | Buffer, format: string) {
+
+//Since it can be either a string or a buffer, don't name it with suffix -String
+function normalizeCert(cert: string | Buffer, format: string) {
   return bin.toString().replace(/\n/g, '').replace(/\r/g, '').replace(`-----BEGIN ${format}-----`, '').replace(`-----END ${format}-----`, '');
 }
 /**
@@ -60,7 +62,7 @@ function _normalizeCerString(bin: string | Buffer, format: string) {
 * @param  {string} certString     declares the certificate contents
 * @return {string} certificiate in string format
 */
-function normalizeCerString(certString: string | Buffer) {
+function normalizeCer(cer: string | Buffer) {
   return _normalizeCerString(certString, 'CERTIFICATE');
 }
 /**
@@ -68,7 +70,7 @@ function normalizeCerString(certString: string | Buffer) {
 * @param  {string} pemString
 * @return {string} private key in string format
 */
-function normalizePemString(pemString: string | Buffer) {
+function normalizePem(pem: string | Buffer) {
   return _normalizeCerString(pemString.toString(), 'RSA PRIVATE KEY');
 }
 /**
@@ -114,7 +116,7 @@ function getPublicKeyPemFromCertificate(x509Certificate: string) {
 * @return {string} string in pem format
 * If passphrase is used to protect the .pem content (recommend)
 */
-function readPrivateKey(keyString: string | Buffer, passphrase: string, isOutputString?: boolean) {
+function readPrivateKey(key: string | Buffer, passphrase: string, isOutputString?: boolean) {
   return typeof passphrase === 'string' ? this.convertToString(pki.privateKeyToPem(pki.decryptRsaPrivateKey(String(keyString), passphrase)), isOutputString) : keyString;
 }
 /**


### PR DESCRIPTION
**This is not to be merged**

This serves as a discussion place for a couple of variable/function naming proposals, I just put it in the form of a PR, since it's easy to add inline comments this way.
I only changed the method signatures for now, nothing else.

It's not a lot. It's basically 3 things:
- methods like `sendX` have been renamed to `createX` since that reflects better what they do.
- avoid including type names in functions/variables. E.g. `pemString`. It doesn't make sense when we use typescript to have the type again in the variable name. + sometimes it can be either a string or buffer, so it's not really correct anyway.
- Some assorted comments on the naming of `rcallback`, why some stuff is done with `require` instead of `import`

If you agree, I can change the implementation/docs/..., but it would be best to do that together with this stuff:
What it does not include:
- Grouping of variables for functions with a lot of variables. Btw, If we group these variables, do we want to create a seperate interface for them?
- Any updates to implementation/examples/inline docs/tests
- this: https://github.com/tngan/express-saml2/issues/50