### PR TITLE
Use native ES2015 features supported by node 4 LTS

### DIFF
--- a/src/entity-idp.ts
+++ b/src/entity-idp.ts
@@ -9,7 +9,7 @@ import utility from './utility';
 import { wording, namespace, tags } from './urn';
 import redirectBinding from './binding-redirect';
 import postBinding from './binding-post';
-import { assign, isString, isArray } from 'lodash';
+import { isString } from 'lodash';
 
 const bindDict = wording.binding;
 const xmlTag = tags.xmlTag;
@@ -51,10 +51,10 @@ export class IdentityProvider extends Entity {
   * @param  {string} meta
   */
   constructor(idpSetting) {
-    let entitySetting = assign({ wantAuthnRequestsSigned: false }, idpSetting);
+    let entitySetting = Object.assign({ wantAuthnRequestsSigned: false }, idpSetting);
     // build attribute part
     if (idpSetting.loginResponseTemplate) {
-      if(isString(idpSetting.loginResponseTemplate.context) && isArray(idpSetting.loginResponseTemplate.attributes)) {
+      if(isString(idpSetting.loginResponseTemplate.context) && Array.isArray(idpSetting.loginResponseTemplate.attributes)) {
         let replacement = {
           AttributeStatement: libsaml.attributeStatementBuilder(idpSetting.loginResponseTemplate.attributes)
         };

--- a/src/entity-sp.ts
+++ b/src/entity-sp.ts
@@ -9,7 +9,6 @@ import utility from './utility';
 import { wording, namespace, tags } from './urn';
 import redirectBinding from './binding-redirect';
 import postBinding from './binding-post';
-import { assign } from 'lodash';
 
 const bindDict = wording.binding;
 const xmlTag = tags.xmlTag;
@@ -34,7 +33,7 @@ export class ServiceProvider extends Entity {
   * @param {string} meta		     metadata
   */
   constructor(spSetting) {
-    const entitySetting = assign({
+    const entitySetting = Object.assign({
       authnRequestsSigned: false,
       wantAssertionsSigned: false
     }, spSetting);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -12,7 +12,7 @@ import IdpMetadata from './metadata-idp';
 import SpMetadata from './metadata-sp';
 import redirectBinding from './binding-redirect';
 import postBinding from './binding-post';
-import { isString, isUndefined, assign } from 'lodash';
+import { isString, isUndefined } from 'lodash';
 
 const dataEncryptionAlgorithm = algorithms.encryption.data;
 const keyEncryptionAlgorithm = algorithms.encryption.key;
@@ -60,7 +60,7 @@ export default class Entity {
   * @param {string} entityMeta is the entity metadata, deprecated after 2.0
   */
   constructor(entitySetting, entityType) {
-    this.entitySetting = assign({}, defaultEntitySetting, entitySetting);
+    this.entitySetting = Object.assign({}, defaultEntitySetting, entitySetting);
     const metadata = entitySetting.metadata ? entitySetting.metadata : entitySetting;
     switch (entityType) {
       case 'idp':

--- a/src/metadata-idp.ts
+++ b/src/metadata-idp.ts
@@ -6,7 +6,7 @@
 import Metadata, { MetadataInterface } from './metadata';
 import { namespace } from './urn';
 import libsaml from './libsaml';
-import { isString, isUndefined, forEach } from 'lodash';
+import { isString, isUndefined } from 'lodash';
 import { isNonEmptyArray } from './utility';
 
 const xml = require('xml');
@@ -65,7 +65,7 @@ export class IdpMetadata extends Metadata {
 
       if (isNonEmptyArray(singleSignOnService)) {
         let indexCount = 0;
-        forEach(singleSignOnService, a => {
+        singleSignOnService.forEach(a => {
           let attr: any = {
             index: String(indexCount++),
             Binding: a.Binding,
@@ -137,7 +137,7 @@ export class IdpMetadata extends Metadata {
     if (isString(binding)) {
       let location;
       let bindName = namespace.binding[binding];
-      forEach(this.meta.singlesignonservice, obj => {
+      this.meta.singlesignonservice.forEach(obj => {
         if (obj[bindName]) {
           location = obj[bindName];
           return;

--- a/src/metadata-sp.ts
+++ b/src/metadata-sp.ts
@@ -6,7 +6,7 @@
 import Metadata, { MetadataInterface } from './metadata';
 import { namespace, elementsOrder as order } from './urn';
 import libsaml from './libsaml';
-import { isString, isArray, forEach, map, filter } from 'lodash';
+import { isString } from 'lodash';
 import { isNonEmptyArray } from './utility';
 
 const xml = require('xml');
@@ -88,12 +88,12 @@ export class SpMetadata extends Metadata {
       }
 
       if (isNonEmptyArray(nameIDFormat)) {
-        forEach(nameIDFormat, f => descriptors.NameIDFormat.push(f));
+        nameIDFormat.forEach(f => descriptors.NameIDFormat.push(f));
       }
 
       if (isNonEmptyArray(singleLogoutService)) {
         let indexCount = 0;
-        forEach(singleLogoutService, a => {
+        singleLogoutService.forEach(a => {
           let attr: any = {
             index: String(indexCount++),
             Binding: a.Binding,
@@ -108,7 +108,7 @@ export class SpMetadata extends Metadata {
 
       if (isNonEmptyArray(assertionConsumerService)) {
         let indexCount = 0;
-        forEach(assertionConsumerService, a => {
+        assertionConsumerService.forEach(a => {
           let attr: any = {
             index: String(indexCount++),
             Binding: a.Binding,
@@ -124,9 +124,9 @@ export class SpMetadata extends Metadata {
       }
 
       // handle element order
-      const existedElements = filter(elementsOrder, name => isNonEmptyArray(descriptors[name]));
-      forEach(existedElements, name => {
-        forEach(descriptors[name], e => SPSSODescriptor.push({ [name]: e }));
+      const existedElements = elementsOrder.filter(name => isNonEmptyArray(descriptors[name]));
+      existedElements.forEach(name => {
+        descriptors[name].forEach(e => SPSSODescriptor.push({ [name]: e }));
       });
 
       meta = xml([{
@@ -182,7 +182,7 @@ export class SpMetadata extends Metadata {
       let location;
       let bindName = namespace.binding[binding];
       if (isNonEmptyArray(this.meta.assertionconsumerservice)) {
-        forEach(this.meta.assertionconsumerservice, obj => {
+        this.meta.assertionconsumerservice.forEach(obj => {
           if (obj.binding === bindName) {
             location = obj.location;
             return;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs';
 import { pki, util, asn1 } from 'node-forge';
 import { inflate, deflate } from 'deflate-js';
-import { isString, isArray, assign } from 'lodash';
+import { isString } from 'lodash';
 
 const BASE64_STR = 'base64';
 const ASCII_STR = 'ascii';
@@ -94,7 +94,7 @@ function parseString(str, defaultValue = '') {
 * @return {object} result object
 */
 function applyDefault(obj1, obj2) {
-  return assign({}, obj1, obj2);
+  return Object.assign({}, obj1, obj2);
 }
 /**
 * @desc Get public key in pem format from the certificate included in the metadata
@@ -127,7 +127,7 @@ function convertToString(input, isOutputString) {
  * @desc Check if the input is an array with non-zero size
  */
 export function isNonEmptyArray(a) {
-  return isArray(a) && a.length > 0;
+  return Array.isArray(a) && a.length > 0;
 }
 
 const utility = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "paths": {},
     "lib": [
       "dom",
+      "es2015.core",
       "es2015.promise",
       "es2015.iterable",
       "es5"


### PR DESCRIPTION
In https://github.com/tngan/express-saml2/issues/51 it was decided to only support latest node and node LTS.

That makes the current oldest supported version node 4, which has native support (http://node.green/) for some of the functions that were used from lodash. This PR replaces those functions with their native version.