### PR TITLE
Fix post install

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pretest": "make pretest",
     "test": "tsc && nyc ava --verbose build/test",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "postinstall": "git config --local include.path ../.gitconfig"
+    "postinstall": "node postinstall"
   },
   "contributors": [
     "Tony Ngan <tonynwk919@gmail.com>"

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,17 +1,16 @@
 const execSync = require('child_process').execSync;
-try{
+
+try {
   const gitDir = execSync('git rev-parse --show-toplevel').toString().trim();
-  if(gitDir !== process.cwd()){
+  if(gitDir !== process.cwd()) {
     console.log(gitDir);
     throw new Error();
   }
-
-  try{
+  try {
     execSync('git config --local include.path ../.gitconfig');
-  }catch(error){
-    console.log("Could not install pre-commit hook")
-  }
-  
-}catch(error){
-  console.log("Not running from git clone, ignoring post install")
+  } catch(error) {
+    console.log('Could not install pre-commit hook');
+  }  
+} catch(error) {
+  console.log('Not running from git clone, ignoring post install');
 }

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,17 @@
+const execSync = require('child_process').execSync;
+try{
+  const gitDir = execSync('git rev-parse --show-toplevel').toString().trim();
+  if(gitDir !== process.cwd()){
+    console.log(gitDir);
+    throw new Error();
+  }
+
+  try{
+    execSync('git config --local include.path ../.gitconfig');
+  }catch(error){
+    console.log("Could not install pre-commit hook")
+  }
+  
+}catch(error){
+  console.log("Not running from git clone, ignoring post install")
+}


### PR DESCRIPTION
Do not run post install hook, which installs the pre-commit git hook if we're not running from a git clone (otherwise errors during npm install).