### PR TITLE
Add extra check on metadata

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -32,6 +32,7 @@ export default class Metadata implements MetadataInterface {
   */
   constructor(xml: string | Buffer, extraParse) {
     this.xmlString = xml.toString();
+
     this.meta = libsaml.extractor(this.xmlString, Array.prototype.concat([{
       localName: 'EntityDescriptor',
       attributes: ['entityID']
@@ -48,6 +49,10 @@ export default class Metadata implements MetadataInterface {
       },
       attributeTag: 'Location'
     }, 'NameIDFormat'], extraParse || []));
+
+    if (!this.meta.entitydescriptor || Array.isArray(this.meta.entitydescriptor)){
+      throw new Error('metadata must contain exactly one entity descriptor');
+    }
   }
   /**
   * @desc Get the metadata in xml format


### PR DESCRIPTION
Some federated IDP's metadata contains a set of entity descriptors (e.g. https://shib.kuleuven.be/download/metadata/metadata-kuleuven.xml ) even with a mix of IDP and SP descriptors.

Although this is valid SAML metadata, this library should be fed exactly 1 entity descriptor.
This is an extra check that throws an error when this is not the case