### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,3 @@
-import 'es6-promise';
 import IdentityProvider from './src/entity-idp';
 import ServiceProvider from './src/entity-sp';
 import IdPMetadata from './src/metadata-idp';

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/xmldom": "^0.1.28",
     "camelcase": "^4.0.0",
     "deflate-js": "^0.2.3",
-    "es6-promise": "^4.0.5",
+
     "lodash": "^3.10.0",
     "node-forge": "^0.6.34",
     "node-rsa": "^0.2.24",

--- a/package.json
+++ b/package.json
@@ -53,23 +53,11 @@
   },
   "devDependencies": {
     "ava": "^0.18.1",
-    "bcryptjs": "^2.2.2",
-    "body-parser": "^1.13.2",
-    "connect-flash": "^0.1.1",
-    "cookie-parser": "^1.3.5",
-    "cors": "^2.7.1",
+  
     "coveralls": "^2.11.16",
-    "debug": "~2.2.0",
-    "express": "^4.13.1",
-    "express-handlebars": "^2.0.1",
-    "express-session": "^1.11.3",
-    "form-data": "^1.0.0-rc3",
-    "http": "0.0.0",
-    "morgan": "^1.6.1",
+   
     "nyc": "^10.1.2",
-    "passport": "^0.2.2",
-    "passport-local": "^1.0.0",
-    "serve-favicon": "^2.3.0",
+   
     "tslint": "4.4.2"
   }
 }


### PR DESCRIPTION
Native pomise is supported in all our targeted versions + removal of dependencies from the removed examples